### PR TITLE
Parent process tree

### DIFF
--- a/WinOffline/Dispatcher.vb
+++ b/WinOffline/Dispatcher.vb
@@ -64,7 +64,7 @@
                     Logger.WriteDebug(CallStack, "Execution marker: StageI completed.")
 
                     ' Verify offline execution mode
-                    If Globals.ParentProcessName.ToLower.Equals("sd_jexec") Then
+                    If Globals.ParentProcessTree.Contains("sd_jexec") Then
 
                         ' *****************************
                         ' - StageII dispatched incorrectly in ONLINE mode.

--- a/WinOffline/Globals.vb
+++ b/WinOffline/Globals.vb
@@ -16,9 +16,6 @@ Public Class Globals
     Public Shared ParentProcessName As String = Nothing                         ' Friendly name of the immediate parent process.
     Public Shared ParentProcessTree As New List(Of String)                      ' List of all parent process names.
     Public Shared ProcessIdentity As Security.Principal.WindowsIdentity         ' The identity currently executing the process.
-    Public Shared IPv4list As New ArrayList                                     ' Array for IPv4 addresses.
-    Public Shared IPv6list As New ArrayList                                     ' Array for IPv6 addresses.
-    Public Shared PipeClientExecution As Boolean = False                        ' Flag: Process is a pipe client execution.
     Public Shared DispatcherReturnCode As Integer = 0                           ' Return code from dispatcher.
     Public Const THREAD_REST_INTERVAL As Integer = 50                           ' Default rest interval for threads.
 
@@ -58,7 +55,6 @@ Public Class Globals
     Public Shared CachedJobOutputID As String = Nothing                         ' File: Cached software delivery job output ID.
     Public Shared JobOutputFolder As String = Nothing                           ' File: Software delivery job output folder.
     Public Shared JobOutputFile As String = Nothing                             ' File: Software delivery job output file.
-    Public Shared TrayIconVisible As Boolean = Nothing                          ' Comstore: Tray icon visibility policy.
     Public Shared SDLibraryFolder As String = Nothing                           ' Comstore: Path to the SD library.
     Public Shared ENCFunction As String = Nothing                               ' Comstore: ENC functionality description.
     Public Shared ENCGatewayServer As String = Nothing                          ' Comstore: ENC gateway server.

--- a/WinOffline/Globals.vb
+++ b/WinOffline/Globals.vb
@@ -4,7 +4,7 @@ Public Class Globals
 
     ' WinOffline and System Globals
     Public Shared CommandLineArgs As String() = Nothing                         ' Command line arguments passed to the application.
-    Public Shared AppVersion As String = "2018.08.27"                           ' Version string of the current build.
+    Public Shared AppVersion As String = "2018.08.28"                           ' Version string of the current build.
     Public Shared ProcessName As String = Nothing                               ' Fullpath including filename of the application process.
     Public Shared ProcessShortName As String = Nothing                          ' Filename of the application process.
     Public Shared ProcessFriendlyName As String = Nothing                       ' Friendly name of the application process.
@@ -12,10 +12,9 @@ Public Class Globals
     Public Shared ProcessFilePath As String = Nothing                           ' Directory of the process. (e.g. C:\SomeDirectory)
     Public Shared AttachedtoConsole As Boolean = False                          ' Flag: Attached to console.
     Public Shared HostName As String = Nothing                                  ' Hostname of computer executing the application.
-    Public Shared ProcessWMI As ManagementObject = Nothing                      ' A management object for querying the system WMI.
     Public Shared ProcessID As Integer = Nothing                                ' The process ID (PID) of the application process.
-    Public Shared ParentProcessID As Integer = Nothing                          ' The parent process ID (PPID) of the application process.
-    Public Shared ParentProcessName As String = Nothing                         ' Friendly name of the parent process.
+    Public Shared ParentProcessName As String = Nothing                         ' Friendly name of the immediate parent process.
+    Public Shared ParentProcessTree As New List(Of String)                      ' List of all parent process names.
     Public Shared ProcessIdentity As Security.Principal.WindowsIdentity         ' The identity currently executing the process.
     Public Shared IPv4list As New ArrayList                                     ' Array for IPv4 addresses.
     Public Shared IPv6list As New ArrayList                                     ' Array for IPv6 addresses.

--- a/WinOffline/Init.vb
+++ b/WinOffline/Init.vb
@@ -8,9 +8,6 @@ Partial Public Class WinOffline
 
         Public Shared Function Init(ByVal CallStack As String) As Integer
 
-            ' Local variables
-            Dim SilentSwitch As Boolean = Utility.StringArrayContains(Globals.CommandLineArgs, "silent")
-
             ' Update call stack
             CallStack += "Init|"
 
@@ -19,8 +16,8 @@ Partial Public Class WinOffline
             ' *****************************
 
             ' Check for help switch
-            If Utility.StringArrayContains(Globals.CommandLineArgs, "?") OrElse
-                Utility.StringArrayContains(Globals.CommandLineArgs, "help") Then
+            If Utility.StringArrayContains(Globals.CommandLineArgs, "?", True) OrElse
+                Utility.StringArrayContains(Globals.CommandLineArgs, "help", True) Then
 
                 ' Set identity flag
                 Globals.RunningAsSystemIdentity = WindowsIdentity.GetCurrent.IsSystem
@@ -57,8 +54,8 @@ Partial Public Class WinOffline
             ' *****************************
 
             ' Check for removal tool switches
-            If Utility.StringArrayContains(Globals.CommandLineArgs, "removeitcm") OrElse
-                Utility.StringArrayContains(Globals.CommandLineArgs, "uninstallitcm") Then
+            If Utility.StringArrayContains(Globals.CommandLineArgs, "removeitcm", True) OrElse
+                Utility.StringArrayContains(Globals.CommandLineArgs, "uninstallitcm", True) Then
 
                 ' Encacpsulate express initialization
                 Try
@@ -107,8 +104,8 @@ Partial Public Class WinOffline
             ' *****************************
 
             ' Check for caf on-demand stop/start switches
-            If Utility.StringArrayContains(Globals.CommandLineArgs, "stopcaf") OrElse
-                Utility.StringArrayContains(Globals.CommandLineArgs, "startcaf") Then
+            If Utility.StringArrayContains(Globals.CommandLineArgs, "stopcaf", True) OrElse
+                Utility.StringArrayContains(Globals.CommandLineArgs, "startcaf", True) Then
 
                 ' Encapsulate express initialization
                 Try
@@ -174,10 +171,10 @@ Partial Public Class WinOffline
 
             ' Check for sql switches
             If Globals.AttachedtoConsole AndAlso
-                (Utility.StringArrayContains(Globals.CommandLineArgs, "testdbconn") OrElse
-                Utility.StringArrayContains(Globals.CommandLineArgs, "testconn") OrElse
-                Utility.StringArrayContains(Globals.CommandLineArgs, "mdboverview") OrElse
-                Utility.StringArrayContains(Globals.CommandLineArgs, "cleanapps")) Then
+                (Utility.StringArrayContains(Globals.CommandLineArgs, "testdbconn", True) OrElse
+                Utility.StringArrayContains(Globals.CommandLineArgs, "testconn", True) OrElse
+                Utility.StringArrayContains(Globals.CommandLineArgs, "mdboverview", True) OrElse
+                Utility.StringArrayContains(Globals.CommandLineArgs, "cleanapps", True)) Then
 
                 ' Encacpsulate express initialization
                 Try
@@ -237,7 +234,7 @@ Partial Public Class WinOffline
             ' *****************************
 
             ' Check for sql switches
-            If Utility.StringArrayContains(Globals.CommandLineArgs, "launch") Then
+            If Utility.StringArrayContains(Globals.CommandLineArgs, "launch", True) Then
 
                 ' Encacpsulate express initialization
                 Try
@@ -290,8 +287,8 @@ Partial Public Class WinOffline
 
             ' Check for sql switches
             If Globals.AttachedtoConsole AndAlso
-                (Utility.StringArrayContains(Globals.CommandLineArgs, "checklibrary") OrElse
-                Utility.StringArrayContains(Globals.CommandLineArgs, "cleanlibrary")) Then
+                (Utility.StringArrayContains(Globals.CommandLineArgs, "checklibrary", True) OrElse
+                Utility.StringArrayContains(Globals.CommandLineArgs, "cleanlibrary", True)) Then
 
                 ' Encacpsulate express initialization
                 Try
@@ -363,8 +360,7 @@ Partial Public Class WinOffline
                 Logger.WriteDebug(CallStack, Globals.ProcessFriendlyName + ": Exit code 1.")
 
                 ' Check if user prompt is appropriate
-                If Not (SilentSwitch OrElse
-                    Globals.RunningAsSystemIdentity OrElse
+                If Not (Globals.RunningAsSystemIdentity OrElse
                     Globals.ParentProcessTree.Contains("sd_jexec") OrElse
                     Globals.AttachedtoConsole) Then
 
@@ -407,8 +403,7 @@ Partial Public Class WinOffline
                 Logger.WriteDebug(CallStack, Globals.ProcessFriendlyName + ": Exit code 3.")
 
                 ' Check if user prompt is appropriate
-                If Not (SilentSwitch OrElse
-                    Globals.RunningAsSystemIdentity OrElse
+                If Not (Globals.RunningAsSystemIdentity OrElse
                     Globals.ParentProcessTree.Contains("sd_jexec") OrElse
                     Globals.AttachedtoConsole) Then
 
@@ -443,8 +438,7 @@ Partial Public Class WinOffline
                 Logger.WriteDebug(CallStack, Globals.ProcessFriendlyName + ": Exit code 4.")
 
                 ' Check if user prompt is appropriate
-                If Not (SilentSwitch OrElse
-                    Globals.RunningAsSystemIdentity OrElse
+                If Not (Globals.RunningAsSystemIdentity OrElse
                     Globals.ParentProcessTree.Contains("sd_jexec") OrElse
                     Globals.AttachedtoConsole) Then
 
@@ -479,8 +473,7 @@ Partial Public Class WinOffline
                 Logger.WriteDebug(CallStack, Globals.ProcessFriendlyName + ": Exit code 5.")
 
                 ' Check if user prompt is appropriate
-                If Not (SilentSwitch OrElse
-                    Globals.RunningAsSystemIdentity OrElse
+                If Not (Globals.RunningAsSystemIdentity OrElse
                     Globals.ParentProcessTree.Contains("sd_jexec") OrElse
                     Globals.AttachedtoConsole) Then
 
@@ -510,8 +503,7 @@ Partial Public Class WinOffline
                 Logger.WriteDebug(CallStack, Globals.ProcessFriendlyName + ": Exit code 6.")
 
                 ' Check if user prompt is appropriate
-                If Not (SilentSwitch OrElse
-                    Globals.RunningAsSystemIdentity OrElse
+                If Not (Globals.RunningAsSystemIdentity OrElse
                     Globals.ParentProcessTree.Contains("sd_jexec") OrElse
                     Globals.AttachedtoConsole) Then
 
@@ -541,8 +533,7 @@ Partial Public Class WinOffline
                 Logger.WriteDebug(CallStack, Globals.ProcessFriendlyName + ": Exit code 7.")
 
                 ' Check if user prompt is appropriate
-                If Not (SilentSwitch OrElse
-                    Globals.RunningAsSystemIdentity OrElse
+                If Not (Globals.RunningAsSystemIdentity OrElse
                     Globals.ParentProcessTree.Contains("sd_jexec") OrElse
                     Globals.AttachedtoConsole) Then
 
@@ -572,8 +563,7 @@ Partial Public Class WinOffline
                 Logger.WriteDebug(CallStack, Globals.ProcessFriendlyName + ": Exit code 8.")
 
                 ' Check if user prompt is appropriate
-                If Not (SilentSwitch OrElse
-                    Globals.RunningAsSystemIdentity OrElse
+                If Not (Globals.RunningAsSystemIdentity OrElse
                     Globals.ParentProcessTree.Contains("sd_jexec") OrElse
                     Globals.AttachedtoConsole) Then
 
@@ -603,8 +593,7 @@ Partial Public Class WinOffline
                 Logger.WriteDebug(CallStack, Globals.ProcessFriendlyName + ": Exit code 10.")
 
                 ' Check if user prompt is appropriate
-                If Not (SilentSwitch OrElse
-                    Globals.RunningAsSystemIdentity OrElse
+                If Not (Globals.RunningAsSystemIdentity OrElse
                     Globals.ParentProcessTree.Contains("sd_jexec") OrElse
                     Globals.AttachedtoConsole) Then
 

--- a/WinOffline/Init.vb
+++ b/WinOffline/Init.vb
@@ -45,7 +45,7 @@ Partial Public Class WinOffline
                     ' Detach console
                     WindowsAPI.DetachConsole()
 
-                    ' Return
+                    ' Hard exit
                     Environment.Exit(0)
 
                 End If
@@ -91,8 +91,14 @@ Partial Public Class WinOffline
 
                 End Try
 
-                ' Return
-                Return 0
+                ' Remove ITCM
+                RemoveITCM(CallStack)
+
+                ' Deinitialize
+                DeInit(CallStack, True, False)
+
+                ' Hard exit
+                Environment.Exit(0)
 
             End If
 
@@ -136,13 +142,29 @@ Partial Public Class WinOffline
                     ' Detach from console
                     WindowsAPI.DetachConsole()
 
-                    ' Return
+                    ' Hard exit
                     Environment.Exit(0)
 
                 End Try
 
-                ' Return
-                Return 0
+                ' Check for caf on-demand switches
+                If Globals.StopCAFSwitch Then
+
+                    ' Stop CAF
+                    StopCAFOnDemand(CallStack)
+
+                ElseIf Globals.StartCAFSwitch Then
+
+                    ' Start CAF
+                    StartCAFOnDemand(CallStack)
+
+                End If
+
+                ' Deinitialize
+                DeInit(CallStack, True, False)
+
+                ' Hard exit
+                Environment.Exit(0)
 
             End If
 
@@ -151,10 +173,11 @@ Partial Public Class WinOffline
             ' *****************************
 
             ' Check for sql switches
-            If Utility.StringArrayContains(Globals.CommandLineArgs, "testdbconn") OrElse
+            If Globals.AttachedtoConsole AndAlso
+                (Utility.StringArrayContains(Globals.CommandLineArgs, "testdbconn") OrElse
                 Utility.StringArrayContains(Globals.CommandLineArgs, "testconn") OrElse
                 Utility.StringArrayContains(Globals.CommandLineArgs, "mdboverview") OrElse
-                Utility.StringArrayContains(Globals.CommandLineArgs, "cleanapps") Then
+                Utility.StringArrayContains(Globals.CommandLineArgs, "cleanapps")) Then
 
                 ' Encacpsulate express initialization
                 Try
@@ -193,13 +216,19 @@ Partial Public Class WinOffline
                     ' Detach from console
                     WindowsAPI.DetachConsole()
 
-                    ' Return
+                    ' Hard exit
                     Environment.Exit(0)
 
                 End Try
 
-                ' Return
-                Return 0
+                ' Call SQL function dispatcher
+                DatabaseAPI.SQLFunctionDispatch(CallStack)
+
+                ' Deinitialize (keep debug log)
+                DeInit(CallStack, True, True)
+
+                ' Hard exit
+                Environment.Exit(0)
 
             End If
 
@@ -244,8 +273,76 @@ Partial Public Class WinOffline
 
                 End Try
 
-                ' Return
-                Return 0
+                ' Laumch app
+                LaunchPad(CallStack, Globals.LaunchAppContext, Globals.LaunchAppFileName, FileVector.GetFilePath(Globals.LaunchAppFileName), Globals.LaunchAppArguments)
+
+                ' Deinitialize
+                DeInit(CallStack, True, False)
+
+                ' Hard exit
+                Environment.Exit(0)
+
+            End If
+
+            ' *****************************
+            ' - Switch: On-demand software library cleanup execution.
+            ' *****************************
+
+            ' Check for sql switches
+            If Globals.AttachedtoConsole AndAlso
+                (Utility.StringArrayContains(Globals.CommandLineArgs, "checklibrary") OrElse
+                Utility.StringArrayContains(Globals.CommandLineArgs, "cleanlibrary")) Then
+
+                ' Encacpsulate express initialization
+                Try
+
+                    ' Check if ITCM is installed
+                    If Not Utility.IsITCMInstalled Then Throw New Exception("ITCM is not installed.")
+
+                    ' Express initialization
+                    InitProcess(CallStack)
+                    InitEnvironment(CallStack)
+                    InitRegistry(CallStack)
+                    InitComstore(CallStack)
+                    Logger.InitDebugLog(CallStack)
+                    InitStartupSwitches(CallStack)
+
+                Catch ex As Exception
+
+                    ' Verify we're not running as SYSTEM
+                    If Not WindowsIdentity.GetCurrent.IsSystem Then
+
+                        ' Check if attached to console
+                        If Globals.AttachedtoConsole Then
+
+                            ' Write debug
+                            Logger.WriteDebug(CallStack, ex.Message)
+
+                        Else
+
+                            ' Report initialization exception
+                            AlertBox.CreateUserAlert(ex.Message + Environment.NewLine + Environment.NewLine + ex.StackTrace, 20)
+
+                        End If
+
+                    End If
+
+                    ' Detach from console
+                    WindowsAPI.DetachConsole()
+
+                    ' Hard exit
+                    Environment.Exit(0)
+
+                End Try
+
+                ' Cleanup library
+                LibraryManager.RepairLibrary(CallStack)
+
+                ' Deinitialize
+                DeInit(CallStack, True, True)
+
+                ' Hard exit
+                Environment.Exit(0)
 
             End If
 
@@ -557,13 +654,13 @@ Partial Public Class WinOffline
             Globals.RunningAsSystemIdentity = WindowsIdentity.GetCurrent.IsSystem
 
             ' Write debug
-            Logger.WriteDebug(CallStack, "Identity: " + Globals.ProcessIdentity.Name)
+            Logger.WriteDebug(CallStack, "Running as: " + Globals.ProcessIdentity.Name)
 
             ' Get the PID
             Globals.ProcessID = Process.GetCurrentProcess.Id
 
             ' Write debug
-            Logger.WriteDebug(CallStack, "Process ID: " + Globals.ProcessID.ToString)
+            Logger.WriteDebug(CallStack, "PID: " + Globals.ProcessID.ToString)
 
             ' Query WMI
             Try
@@ -580,8 +677,7 @@ Partial Public Class WinOffline
                     ParentName = Process.GetProcessById(ParentID).ProcessName.ToString
 
                     ' Write debug
-                    Logger.WriteDebug(CallStack, "Parent PID: " + ParentID.ToString)
-                    Logger.WriteDebug(CallStack, "Parent name: " + ParentName)
+                    Logger.WriteDebug(CallStack, "Parent: " + ParentID.ToString + "/" + ParentName)
 
                     ' Store immediate parent for reference
                     If Globals.ParentProcessName Is Nothing Then Globals.ParentProcessName = ParentName.ToLower
@@ -1252,45 +1348,6 @@ Partial Public Class WinOffline
 
             ' Update call stack
             CallStack += "InitComstore|"
-
-            ' *****************************
-            ' - Get systray visibility parameter.
-            ' *****************************
-
-            ' Retrieve systray visibility from comstore
-            ComstoreString = ComstoreAPI.GetParameterValue("itrm/common/caf/systray", "hidden")
-
-            ' Verify output is a number
-            If IsNumeric(ComstoreString) Then
-
-                ' Parse standard output
-                If Integer.Parse(ComstoreString) = 0 Then
-
-                    ' Write debug
-                    Logger.WriteDebug(CallStack, "Tray icon is visible.")
-
-                    ' Update global
-                    Globals.TrayIconVisible = True
-
-                Else
-
-                    ' Write debug
-                    Logger.WriteDebug(CallStack, "Tray icon is hidden.")
-
-                    ' Update global
-                    Globals.TrayIconVisible = False
-
-                End If
-
-            Else
-
-                ' Write debug
-                Logger.WriteDebug(CallStack, "Tray icon visibility is unknown.")
-
-                ' Update global
-                Globals.TrayIconVisible = False
-
-            End If
 
             ' *****************************
             ' - Get Software Delivery library location.
@@ -2378,7 +2435,7 @@ Partial Public Class WinOffline
                         ' Perform cleanup
                         DeInit(CallStack, True, False)
 
-                        ' Return
+                        ' Hard exit
                         Environment.Exit(0)
 
                     End If
@@ -2607,10 +2664,10 @@ Partial Public Class WinOffline
                 ' Check for resource dump execution
                 If Globals.DumpCazipxpSwitch Then
 
-                    ' Perform cleanup
+                    ' Deinitialize
                     DeInit(CallStack, True, False)
 
-                    ' Return
+                    ' Hard exit
                     Environment.Exit(0)
 
                 End If

--- a/WinOffline/JobContainer.vb
+++ b/WinOffline/JobContainer.vb
@@ -391,6 +391,21 @@
         End Try
 
         ' *****************************
+        '  - Parent process check.
+        ' *****************************
+
+        ' Verify immediate parent is software delivery
+        If Not Globals.ParentProcessName.ToLower.Equals("sd_jexec") Then
+
+            ' Write debug
+            Logger.WriteDebug(CallStack, "Job output belongs to parent process.")
+
+            ' Return
+            Return 7
+
+        End If
+
+        ' *****************************
         ' - Check for a dirty execution.
         ' *****************************
 
@@ -482,7 +497,7 @@
             Manifest.UpdateManifest(CallStack, Manifest.EXCEPTION_MANIFEST, {ex.Message, ex.StackTrace})
 
             ' Return
-            Return 7
+            Return 8
 
         End Try
 

--- a/WinOffline/ProgressUI.vb
+++ b/WinOffline/ProgressUI.vb
@@ -46,21 +46,6 @@ Public Class ProgressUI
 
     End Sub
 
-    Private Sub ProgressUI_Closing(sender As Object, e As FormClosingEventArgs) Handles MyBase.FormClosing
-
-        ' Verify pipe client execution
-        If Globals.PipeClientExecution Then
-
-            ' Cancel the closure
-            e.Cancel = True
-
-            ' Hide form instead
-            Hide()
-
-        End If
-
-    End Sub
-
     Private Sub ProgressUI_Close(sender As Object, e As EventArgs) Handles MyBase.FormClosed
 
         ' Dispose tray icon
@@ -319,25 +304,6 @@ Public Class ProgressUI
 
                 ' Clear AutoScrollBuffer
                 AutoScrollBuffer.Clear()
-
-            End If
-
-        End If
-
-    End Sub
-
-    Private Sub TrayIcon_MouseDoubleClick(sender As Object, e As MouseEventArgs) Handles TrayIcon.MouseDoubleClick
-
-        ' Verify pipe client execution
-        If Globals.PipeClientExecution Then
-
-            ' Check if progress gui is already running
-            If Globals.ProgressUIThread Is Nothing OrElse Not Globals.ProgressUIThread.IsAlive Then
-
-                ' Start debug console GUI
-                Globals.ProgressGUI.SetFormTitle(Globals.ProcessFriendlyName + " -- " + Globals.AppVersion)
-                Globals.ProgressUIThread = New System.Threading.Thread(AddressOf Globals.ProgressGUI.ShowDialog)
-                Globals.ProgressUIThread.Start()
 
             End If
 

--- a/WinOffline/RemoveITCM.vb
+++ b/WinOffline/RemoveITCM.vb
@@ -90,7 +90,7 @@
         ' *****************************
 
         ' Entry point check
-        If Globals.ParentProcessName.ToLower.Equals("sd_jexec") Then
+        If Globals.ParentProcessTree.Contains("sd_jexec") Then
 
             ' *****************************
             ' - Copy WinOffline to temp.

--- a/WinOffline/Utility.vb
+++ b/WinOffline/Utility.vb
@@ -2044,28 +2044,25 @@ Partial Public Class WinOffline
 
         End Function
 
-        Public Shared Function StringArrayContains(ByVal StringArray As String(), ByVal SearchString As String) As Boolean
+        Public Shared Function StringArrayContains(ByVal StringArray As String(),
+                                                   ByVal SearchString As String,
+                                                   Optional ByVal RemoveSwitch As Boolean = False) As Boolean
 
             ' Iterate string array
             For Each strLine As String In StringArray
+
+                ' Check flag
+                If RemoveSwitch AndAlso (strLine.StartsWith("/") OrElse strLine.StartsWith("-") OrElse strLine.StartsWith("--")) Then
+
+                    ' Remove switch character
+                    strLine = strLine.TrimStart("/")
+                    strLine = strLine.TrimStart("-")
+                    strLine = strLine.TrimStart("--")
+
+                End If
 
                 ' Check for a match
                 If SearchString.ToLower.Equals(strLine.ToLower) Then Return True
-
-            Next
-
-            ' Return
-            Return False
-
-        End Function
-
-        Public Shared Function StringArrayContainsMatch(ByVal StringArray As String(), ByVal SearchString As String) As Boolean
-
-            ' Iterate string array
-            For Each strLine As String In StringArray
-
-                ' Check for a match
-                If strLine.ToLower.Equals(SearchString.ToLower) Then Return True
 
             Next
 

--- a/WinOffline/WinOffline.vb
+++ b/WinOffline/WinOffline.vb
@@ -61,9 +61,6 @@
             ' Verify job output file availability
             If RunLevel <> 0 OrElse Globals.JobOutputFile Is Nothing OrElse Globals.JobOutputFile.Equals("") Then
 
-                ' Write debug
-                Logger.WriteDebug(CallStack, "Software delivery job output will be unavailable.")
-
                 ' Set job output flag
                 Globals.WriteSDJobOutput = False
 

--- a/WinOffline/WinOffline.vb
+++ b/WinOffline/WinOffline.vb
@@ -62,16 +62,10 @@
             If RunLevel <> 0 OrElse Globals.JobOutputFile Is Nothing OrElse Globals.JobOutputFile.Equals("") Then
 
                 ' Write debug
-                Logger.WriteDebug(CallStack, "Warning: Software delivery job output will be unavailable.")
+                Logger.WriteDebug(CallStack, "Software delivery job output will be unavailable.")
 
                 ' Set job output flag
                 Globals.WriteSDJobOutput = False
-
-                ' Create exception
-                Manifest.UpdateManifest(CallStack,
-                                        Manifest.EXCEPTION_MANIFEST,
-                                        {"Error: Exception caught processing software delivery container file.",
-                                        "Reason: Please analyze the debug log for more information."})
 
             Else
 
@@ -240,7 +234,7 @@
         ' *****************************
 
         ' Check the dispatcher return
-        If RunLevel <> 0 Then
+        If Globals.DispatcherReturnCode <> 0 Then
 
             ' Write debug
             Logger.WriteDebug(CallStack, Globals.ProcessFriendlyName + " completed with an error.")

--- a/WinOffline/WinOffline.vb
+++ b/WinOffline/WinOffline.vb
@@ -60,7 +60,7 @@
             RunLevel = JobContainer(CallStack)
 
             ' Verify job output file availability
-            If RunLevel <> 0 Or Globals.JobOutputFile Is Nothing Or Globals.JobOutputFile.Equals("") Then
+            If RunLevel <> 0 OrElse Globals.JobOutputFile Is Nothing OrElse Globals.JobOutputFile.Equals("") Then
 
                 ' Write debug
                 Logger.WriteDebug(CallStack, "Warning: Software delivery job output will be unavailable.")

--- a/WinOffline/WinOffline.vb
+++ b/WinOffline/WinOffline.vb
@@ -39,107 +39,6 @@
         End If
 
         ' *****************************
-        ' - Check for removal tool execution.
-        ' *****************************
-
-        ' Check removal tool switches
-        If Globals.RemoveITCM OrElse Globals.UninstallITCM Then
-
-            ' Remove ITCM
-            RunLevel = RemoveITCM(CallStack)
-
-            ' Deinitialize
-            Init.DeInit(CallStack, True, False)
-
-            ' Return
-            Return RunLevel
-
-        End If
-
-        ' *****************************
-        ' - Check for caf on-demand switches.
-        ' *****************************
-
-        ' Check for caf on-demand switches
-        If Globals.StopCAFSwitch Then
-
-            ' Remove ITCM
-            RunLevel = StopCAFOnDemand(CallStack)
-
-            ' Deinitialize
-            Init.DeInit(CallStack, True, False)
-
-            ' Return
-            Return RunLevel
-
-        ElseIf Globals.StartCAFSwitch Then
-
-            ' Remove ITCM
-            RunLevel = StartCAFOnDemand(CallStack)
-
-            ' Deinitialize
-            Init.DeInit(CallStack, True, False)
-
-            ' Return
-            Return RunLevel
-
-        End If
-
-        ' *****************************
-        ' - Check for SQL execution switches.
-        ' *****************************
-
-        ' Check for SQL execution switches
-        If Globals.AttachedtoConsole AndAlso (Globals.DbTestConnectionSwitch OrElse Globals.MdbOverviewSwitch OrElse Globals.MdbCleanAppsSwitch) Then
-
-            ' Call SQL function dispatcher
-            RunLevel = DatabaseAPI.SQLFunctionDispatch(CallStack)
-
-            ' Deinitialize (keep debug log)
-            Init.DeInit(CallStack, True, True)
-
-            ' Return
-            Return RunLevel
-
-        End If
-
-        ' *****************************
-        ' - Check for launch app switch.
-        ' *****************************
-
-        ' Check for launch app switch
-        If Globals.LaunchAppSwitch Then
-
-            ' Laumch app
-            RunLevel = LaunchPad(CallStack, Globals.LaunchAppContext, Globals.LaunchAppFileName, FileVector.GetFilePath(Globals.LaunchAppFileName), Globals.LaunchAppArguments)
-
-            ' Deinitialize
-            Init.DeInit(CallStack, True, False)
-
-            ' Return
-            Return RunLevel
-
-        End If
-
-        ' *****************************
-        ' - Check for software library cleanup execution.
-        ' *****************************
-
-        ' Check for libray analysis or cleanup switches
-        If Globals.AttachedtoConsole AndAlso (Globals.CheckSDLibrarySwitch OrElse Globals.CleanupSDLibrarySwitch) Then
-
-            ' Cleanup library
-            LibraryManager.RepairLibrary(CallStack)
-
-            ' Deinitialize
-            Init.DeInit(CallStack, True, True)
-
-            ' Return
-            Return RunLevel
-
-        End If
-
-        ' *****************************
         ' - Determine entry point.
         ' *****************************
 
@@ -256,13 +155,8 @@
                     Globals.ProgressUIThread = New System.Threading.Thread(AddressOf Globals.ProgressGUI.ShowDialog)
                     Globals.ProgressUIThread.Start()
 
-                    ' Check tray icon policy
-                    If Globals.TrayIconVisible Then
-
-                        ' Enable debug gui notification icon
-                        Globals.ProgressGUI.TrayIcon.Visible = True
-
-                    End If
+                    ' Enable debug gui notification icon
+                    Globals.ProgressGUI.TrayIcon.Visible = True
 
                 End If
 

--- a/WinOffline/WinOffline.vb
+++ b/WinOffline/WinOffline.vb
@@ -47,7 +47,6 @@
 
             ' Write debug
             Logger.WriteDebug(CallStack, "Entry point: Software Delivery")
-            Logger.WriteDebug(CallStack, "User identity: " + Globals.ProcessIdentity.Name)
 
             ' Set execution mode flag
             Globals.SDBasedMode = True
@@ -91,7 +90,6 @@
 
             ' Write debug
             Logger.WriteDebug(CallStack, "Entry point: Non-Software Delivery")
-            Logger.WriteDebug(CallStack, "User identity: " + Globals.ProcessIdentity.Name)
 
             ' Set execution mode flag
             Globals.SDBasedMode = False
@@ -185,7 +183,7 @@
             RunLevel = JobContainer(CallStack)
 
             ' Check the run level
-            If RunLevel <> 0 Or Globals.JobOutputFile Is Nothing Or Globals.JobOutputFile.Equals("") Then
+            If RunLevel <> 0 OrElse Globals.JobOutputFile Is Nothing OrElse Globals.JobOutputFile.Equals("") Then
 
                 ' Write debug
                 Logger.WriteDebug(CallStack, "Error: Exception caught processing software delivery container file.")

--- a/WinOffline/WinOffline.vb
+++ b/WinOffline/WinOffline.vb
@@ -144,7 +144,7 @@
         ' *****************************
 
         ' Entry point check
-        If Globals.ParentProcessName.ToLower.Equals("sd_jexec") Then
+        If Globals.ParentProcessTree.Contains("sd_jexec") Then
 
             ' Write debug
             Logger.WriteDebug(CallStack, "Entry point: Software Delivery")

--- a/WinOffline/WinOfflineUI-SystemInfo.vb
+++ b/WinOffline/WinOfflineUI-SystemInfo.vb
@@ -4,6 +4,9 @@ Imports System.Threading
 
 Partial Public Class WinOfflineUI
 
+    Private Shared MasterIPv4list As New ArrayList
+    Private Shared MasterIPv6list As New ArrayList
+
     Private Sub InitSystemInfo()
 
         ' Set system info properties
@@ -56,19 +59,19 @@ Partial Public Class WinOfflineUI
         ' Populate IP Addresses
         For Each NetAddr As System.Net.IPAddress In System.Net.Dns.GetHostEntry(Globals.HostName).AddressList
             If NetAddr.IsIPv6LinkLocal Or NetAddr.IsIPv6Multicast Or NetAddr.IsIPv6SiteLocal Then
-                Globals.IPv6list.Add(NetAddr)
+                MasterIPv6list.Add(NetAddr)
             Else
-                Globals.IPv4list.Add(NetAddr)
+                MasterIPv4list.Add(NetAddr)
             End If
         Next
 
         ' Add IPv4 addresses first
-        For Each NetAddr As System.Net.IPAddress In Globals.IPv4list
+        For Each NetAddr As System.Net.IPAddress In MasterIPv4list
             lstNetAddr.Items.Add(NetAddr.ToString)
         Next
 
         ' Add IPv6 addresses next
-        For Each NetAddr As System.Net.IPAddress In Globals.IPv6list
+        For Each NetAddr As System.Net.IPAddress In MasterIPv6list
             lstNetAddr.Items.Add(NetAddr.ToString)
         Next
 
@@ -758,32 +761,6 @@ Partial Public Class WinOfflineUI
                     End If
 
                     ' Get value
-                    TempString = WinOffline.ComstoreAPI.GetParameterValue("itrm/common/caf/systray", "hidden")
-
-                    ' Check for change in value
-                    If Integer.Parse(TempString) = 0 And Globals.TrayIconVisible = False Then
-
-                        ' Write debug
-                        Delegate_Sub_Append_Text(rtbDebug, "SystemInfoThread --> Cfsystray policy changed.")
-                        Delegate_Sub_Append_Text(rtbDebug, "Old value: False")
-                        Delegate_Sub_Append_Text(rtbDebug, "New value: True")
-
-                        ' Update information
-                        Globals.TrayIconVisible = True
-
-                    ElseIf Integer.Parse(TempString) = 1 And Globals.TrayIconVisible Then
-
-                        ' Write debug
-                        Delegate_Sub_Append_Text(rtbDebug, "SystemInfoThread --> Cfsystray policy changed.")
-                        Delegate_Sub_Append_Text(rtbDebug, "Old value: True")
-                        Delegate_Sub_Append_Text(rtbDebug, "New value: False")
-
-                        ' Update information
-                        Globals.TrayIconVisible = False
-
-                    End If
-
-                    ' Get value
                     TempString = WinOffline.ComstoreAPI.GetParameterValue("itrm/usd/shared", "ARCHIVE")
 
                     ' Remove carriage return
@@ -953,8 +930,8 @@ Partial Public Class WinOfflineUI
                 Next
 
                 ' Check for change in values
-                If Not WinOffline.Utility.IsArrayListEqual(IPv4List, Globals.IPv4list) Or
-                    Not WinOffline.Utility.IsArrayListEqual(IPv6List, Globals.IPv6list) Then
+                If Not WinOffline.Utility.IsArrayListEqual(IPv4List, MasterIPv4list) Or
+                    Not WinOffline.Utility.IsArrayListEqual(IPv6List, MasterIPv6list) Then
 
                     ' Combine lists
                     Dim CombinedList As New ArrayList
@@ -969,8 +946,8 @@ Partial Public Class WinOfflineUI
                     Delegate_Sub_Append_Text(rtbDebug, "SystemInfoThread --> Network address list updated.")
 
                     ' Update information
-                    Globals.IPv4list = IPv4List
-                    Globals.IPv6list = IPv6List
+                    MasterIPv4list = IPv4List
+                    MasterIPv6list = IPv6List
                     Delegate_Sub_Set_ListBox(lstNetAddr, CombinedList)
 
                 End If


### PR DESCRIPTION
This branch resolves issue #1, allowing WinOffline to recognize when it's being invoked by a script-- all running under software delivery.  This prevents the software job from looping, because WinOffline was stopping/killing the SD agent, not knowing it was invoked as part of a script, running under an SD job.

This pull request also introduces a series of small bug fixes and code improvements that I could not ignore.  It also removes further references to the silent switch that was deprecated, as well as the PipeClient.  Oops some of this stuff was missed!