### PR TITLE
Merge Dispatcher logic updates

### DIFF
--- a/WinOffline/Init.vb
+++ b/WinOffline/Init.vb
@@ -1347,7 +1347,7 @@ Partial Public Class WinOffline
         '     or incomplete executions where stage III was never run.
         '   This is detected when we process the SD job container, and the cached
         '     ID for the job doesn't match the current ID (JobContainer.vb).
-        Public Shared Function SDStageIReInit(ByVal CallStack As String) As Integer
+        Public Shared Function ReInit(ByVal CallStack As String) As Integer
 
             CallStack += "ReInit|"
 
@@ -1391,7 +1391,7 @@ Partial Public Class WinOffline
 
             ' Re-init debug log
             Logger.WriteDebug(CallStack, "Reinitialize debug log..")
-            Logger.SDStageIReInitDebugLog()
+            Logger.ReInitDebugLog()
             Logger.WriteDebug(CallStack, "Debug log reinitialized.")
 
             Return 0

--- a/WinOffline/JobContainer.vb
+++ b/WinOffline/JobContainer.vb
@@ -182,7 +182,7 @@
         If Globals.CachedJobOutputID IsNot Nothing Then
             If Not Globals.CachedJobOutputID.Equals(Globals.CurrentJobOutputID) Then
                 Logger.WriteDebug(CallStack, "Error: Current job output ID does not match cached ID.")
-                RunLevel = Init.SDStageIReInit(CallStack)
+                RunLevel = Init.ReInit(CallStack)
                 If RunLevel <> 0 Then
                     Manifest.UpdateManifest(CallStack,
                                             Manifest.EXCEPTION_MANIFEST,

--- a/WinOffline/Logger.vb
+++ b/WinOffline/Logger.vb
@@ -412,7 +412,7 @@
 
         End Sub
 
-        Public Shared Sub SDStageIReInitDebugLog()
+        Public Shared Sub ReInitDebugLog()
 
             ' Referenced by Init.SDStageIReInit().
             ' Allows the prior debugging from a failed job to be purged.


### PR DESCRIPTION
**Dispatcher.vb** logic extended, to detect and cleanup prior unfinished SD-based executions, when WinOffline is invoked in a user-driven mode.

Test changes by sending an SD job to run Stages 1 and 2, but terminated the container before Stage3 could be triggered.  Tested both GUI and CLI modes, to ensure prior execution got cleaned up, as expected, and then continued to carry out current execution without issue.

Also tested a normal SD job, Stage1, Stage2, Stage3, to ensure unaffected.

Neglected to test running an SD job as a user account, or a Standalone execution as the SYSTEM account, but both scenarios were in-mind when making these changes.  Don't feel a need to test the extreme/rare cases.