### PR TITLE
Parent process traversal

### DIFF
--- a/WinOffline/Globals.vb
+++ b/WinOffline/Globals.vb
@@ -4,7 +4,7 @@ Public Class Globals
 
     ' WinOffline and System Globals
     Public Shared CommandLineArgs As String() = Nothing                         ' Command line arguments passed to the application.
-    Public Shared AppVersion As String = "2018.09.26"                           ' Version string of the current build.
+    Public Shared AppVersion As String = "2018.09.27"                           ' Version string of the current build.
     Public Shared ProcessName As String = Nothing                               ' Fullpath including filename of the application process.
     Public Shared ProcessShortName As String = Nothing                          ' Filename of the application process.
     Public Shared ProcessFriendlyName As String = Nothing                       ' Friendly name of the application process.

--- a/WinOffline/My Project/AssemblyInfo.vb
+++ b/WinOffline/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("2018.05.22")>
-<Assembly: AssemblyFileVersion("2018.05.22")>
+<Assembly: AssemblyVersion("2018.09.27")>
+<Assembly: AssemblyFileVersion("2018.09.27")>

--- a/WinOffline/StopServices.vb
+++ b/WinOffline/StopServices.vb
@@ -414,7 +414,7 @@ Partial Public Class WinOffline
                     ConsoleOutput = RunningProcess.StandardOutput.ReadLine
                     Logger.WriteDebug(ConsoleOutput)
                     StandardOutput += ConsoleOutput + Environment.NewLine
-                    If ConsoleOutput IsNot Nothing AndAlso ConsoleOutput.ToLower.Contains(" 260 ") Then
+                    If ConsoleOutput IsNot Nothing AndAlso ConsoleOutput.ToLower.Contains(" 240 ") Then
                         CAFStopHelperThread = New Thread(Sub() CafStopWorker())
                         CAFStopHelperThread.Start()
                     End If
@@ -781,13 +781,13 @@ Partial Public Class WinOffline
                 Logger.WriteDebug("Helper thread: Monitoring (" + CafProcessList.Count.ToString + ") processes.")
                 LoopCounter = 0
 
-                While LoopCounter < 50
+                While LoopCounter < 20
                     If Not Utility.IsProcessRunning("caf.exe", "stop") Then
                         Logger.WriteDebug("Helper thread: Finished.")
                         Return
                     End If
                     LoopCounter += 1
-                    Thread.Sleep(50)
+                    Thread.Sleep(500)
                 End While
 
                 For x As Integer = CafProcessList.Count - 1 To 0 Step -1

--- a/WinOffline/StopServices.vb
+++ b/WinOffline/StopServices.vb
@@ -792,10 +792,8 @@ Partial Public Class WinOffline
 
                 For x As Integer = CafProcessList.Count - 1 To 0 Step -1
                     ChildProcess = CafProcessList(x)
-                    Logger.WriteDebug("Helper thread: Analyzing PID " + ChildProcess.Item(0).ToString + " -- " + ChildProcess.Item(1).ToString)
 
                     If Not Utility.IsProcessRunning(Integer.Parse(ChildProcess.Item(0))) Then
-                        Logger.WriteDebug("Helper thread: Self-terminated PID " + ChildProcess.Item(0).ToString + " -- " + ChildProcess.Item(1).ToString)
                         CafProcessList.RemoveAt(x)
                         Continue For
                     End If

--- a/WinOffline/Utility.vb
+++ b/WinOffline/Utility.vb
@@ -651,14 +651,13 @@ Partial Public Class WinOffline
                             While True
                                 ProcessWMI = New ManagementObject("Win32_Process.Handle='" & CurrentID & "'")
                                 ParentID = ProcessWMI("ParentProcessID")
+                                If Not Integer.TryParse(ParentID, Nothing) OrElse ParentID <= 0 Then Exit While
                                 ParentName = Process.GetProcessById(ParentID).ProcessName.ToString
                                 Logger.WriteDebug(Logger.LastCallStack, "IsProcessRunning() parent: " + ParentID.ToString + "/" + ParentName)
-                                If Globals.ParentProcessName Is Nothing Then Globals.ParentProcessName = ParentName.ToLower
-                                Globals.ParentProcessTree.Add(ParentName.ToLower)
                                 CurrentID = ParentID
                             End While
                         Catch ex As Exception
-                            If Globals.ParentProcessName Is Nothing Then Globals.ParentProcessName = "noparent"
+                            ' Do nothing
                         End Try
                     End If
                     Return True

--- a/WinOffline/WinOfflineUI-CafStopStart.vb
+++ b/WinOffline/WinOfflineUI-CafStopStart.vb
@@ -331,9 +331,7 @@ Partial Public Class WinOfflineUI
 
                 For x As Integer = CafProcessList.Count - 1 To 0 Step -1
                     ChildProcess = CafProcessList(x)
-                    Delegate_Sub_Append_Text(UIOutputControl, "Helper thread: Analyzing PID " + ChildProcess.Item(0).ToString + " -- " + ChildProcess.Item(1).ToString)
                     If Not WinOffline.Utility.IsProcessRunning(Integer.Parse(ChildProcess.Item(0))) Then
-                        Delegate_Sub_Append_Text(UIOutputControl, "Helper thread: Self-terminated PID " + ChildProcess.Item(0).ToString + " -- " + ChildProcess.Item(1).ToString)
                         CafProcessList.RemoveAt(x)
                         Continue For
                     End If

--- a/WinOffline/WinOfflineUI-CafStopStart.vb
+++ b/WinOffline/WinOfflineUI-CafStopStart.vb
@@ -320,13 +320,13 @@ Partial Public Class WinOfflineUI
                 Delegate_Sub_Append_Text(UIOutputControl, "Helper thread: Monitoring (" + CafProcessList.Count.ToString + ") processes.")
                 LoopCounter = 0
 
-                While LoopCounter < 50
+                While LoopCounter < 20
                     If Not WinOffline.Utility.IsProcessRunning("caf.exe", "stop") Then
                         Delegate_Sub_Append_Text(UIOutputControl, "Helper thread: Finished.")
                         Return
                     End If
                     LoopCounter += 1
-                    Thread.Sleep(50)
+                    Thread.Sleep(500)
                 End While
 
                 For x As Integer = CafProcessList.Count - 1 To 0 Step -1


### PR DESCRIPTION
Made changes to parent process traversal inside Init.InitProcess().  Basically added a check on the ParentID, to make sure WMI returns a valid integer that is positive in value (also non-zero).  Otherwise it breaks the traversal loop.  After adding this safety, I have not been able to reproduce the same problem.

Reflected the changes in Utility.IsProcessRunning(), as MoreInfo=True would also traverse parent process information.  While reflecting changes, found some bugs there, brought on by a crude copy/paste of the previous parent traversal code-- it had references to Globals.ParentProcessName and Globals.ParentProcessTree, which should only be referenced by Init.InitProcess, and not for a quick Utility.IsProcessRunning() check.  Anyway it is fixed.

