### PR TITLE
Missing temp folder

### DIFF
--- a/WinOffline/Globals.vb
+++ b/WinOffline/Globals.vb
@@ -4,7 +4,7 @@ Public Class Globals
 
     ' WinOffline and System Globals
     Public Shared CommandLineArgs As String() = Nothing                         ' Command line arguments passed to the application.
-    Public Shared AppVersion As String = "2018.10.12"                           ' Version string of the current build.
+    Public Shared AppVersion As String = "2018.10.18"                           ' Version string of the current build.
     Public Shared ProcessName As String = Nothing                               ' Fullpath including filename of the application process.
     Public Shared ProcessShortName As String = Nothing                          ' Filename of the application process.
     Public Shared ProcessFriendlyName As String = Nothing                       ' Friendly name of the application process.

--- a/WinOffline/Globals.vb
+++ b/WinOffline/Globals.vb
@@ -4,7 +4,7 @@ Public Class Globals
 
     ' WinOffline and System Globals
     Public Shared CommandLineArgs As String() = Nothing                         ' Command line arguments passed to the application.
-    Public Shared AppVersion As String = "2018.10.11"                           ' Version string of the current build.
+    Public Shared AppVersion As String = "2018.10.12"                           ' Version string of the current build.
     Public Shared ProcessName As String = Nothing                               ' Fullpath including filename of the application process.
     Public Shared ProcessShortName As String = Nothing                          ' Filename of the application process.
     Public Shared ProcessFriendlyName As String = Nothing                       ' Friendly name of the application process.

--- a/WinOffline/Globals.vb
+++ b/WinOffline/Globals.vb
@@ -4,7 +4,7 @@ Public Class Globals
 
     ' WinOffline and System Globals
     Public Shared CommandLineArgs As String() = Nothing                         ' Command line arguments passed to the application.
-    Public Shared AppVersion As String = "2018.10.18"                           ' Version string of the current build.
+    Public Shared AppVersion As String = "2018.10.19"                           ' Version string of the current build.
     Public Shared ProcessName As String = Nothing                               ' Fullpath including filename of the application process.
     Public Shared ProcessShortName As String = Nothing                          ' Filename of the application process.
     Public Shared ProcessFriendlyName As String = Nothing                       ' Friendly name of the application process.

--- a/WinOffline/Globals.vb
+++ b/WinOffline/Globals.vb
@@ -4,7 +4,7 @@ Public Class Globals
 
     ' WinOffline and System Globals
     Public Shared CommandLineArgs As String() = Nothing                         ' Command line arguments passed to the application.
-    Public Shared AppVersion As String = "2018.10.04"                           ' Version string of the current build.
+    Public Shared AppVersion As String = "2018.10.11"                           ' Version string of the current build.
     Public Shared ProcessName As String = Nothing                               ' Fullpath including filename of the application process.
     Public Shared ProcessShortName As String = Nothing                          ' Filename of the application process.
     Public Shared ProcessFriendlyName As String = Nothing                       ' Friendly name of the application process.

--- a/WinOffline/Manifest.vb
+++ b/WinOffline/Manifest.vb
@@ -440,7 +440,9 @@
                             For x As Integer = 0 To GetPatchFromManifest(i).DestReplaceList.Count - 1
                                 ReplaceFile = GetPatchFromManifest(i).DestReplaceList.Item(x)
                                 PatchSummary += "- " + ReplaceFile + " ["
-                                If GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_SKIPPED Then
+                                If GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_REVERSED Then
+                                    PatchSummary += "CHANGES REVERSED]" + Environment.NewLine
+                                ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_SKIPPED Then
                                     PatchSummary += "SKIPPED]" + Environment.NewLine
                                 ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_OK Then
                                     PatchSummary += "OK]" + Environment.NewLine

--- a/WinOffline/Manifest.vb
+++ b/WinOffline/Manifest.vb
@@ -235,7 +235,7 @@
                 PatchSummary += "No exceptions thrown." + Environment.NewLine
             Else
                 For i As Integer = 0 To ExceptionManifest.Count() - 1
-                    PatchSummary += Environment.NewLine + "Exception #" + ExceptionCounter.ToString + ": " + ExceptionManifest.Item(i).ToString + Environment.NewLine
+                    PatchSummary += "Exception #" + ExceptionCounter.ToString + ": " + ExceptionManifest.Item(i).ToString + Environment.NewLine
                     For j As Integer = i + 1 To ExceptionManifest.Count() - 1
                         If ExceptionManifest.Item(j).ToString.Equals("//BREAK//") Then
                             i = j
@@ -302,7 +302,7 @@
                 PatchSummary += "No exceptions thrown." + Environment.NewLine
             Else
                 For i As Integer = 0 To ExceptionManifest.Count() - 1
-                    PatchSummary += Environment.NewLine + "Exception #" + ExceptionCounter.ToString + ": " + ExceptionManifest.Item(i).ToString + Environment.NewLine
+                    PatchSummary += "Exception #" + ExceptionCounter.ToString + ": " + ExceptionManifest.Item(i).ToString + Environment.NewLine
                     For j As Integer = i + 1 To ExceptionManifest.Count() - 1
                         If ExceptionManifest.Item(j).ToString.Equals("//BREAK//") Then
                             i = j

--- a/WinOffline/Manifest.vb
+++ b/WinOffline/Manifest.vb
@@ -413,10 +413,17 @@
                                 CommandFile = GetPatchFromManifest(i).GetPreCommandList.Item(x)
                                 If GetPatchFromManifest(i).PreCmdReturnCodes.Count > x Then
                                     ReturnCode = GetPatchFromManifest(i).PreCmdReturnCodes.Item(x)
+                                    PatchSummary += "- " + CommandFile + " [Return Code: " + ReturnCode + "]" + Environment.NewLine
                                 Else
-                                    ReturnCode = "SKIPPED"
+                                    If GetPatchFromManifest(i).PatchAction = PatchVector.EXECUTE_FAIL OrElse
+                                        GetPatchFromManifest(i).PatchAction = PatchVector.APPLY_FAIL Then
+                                        ReturnCode = "FAILED"
+                                        PatchSummary += "- " + CommandFile + " [" + ReturnCode + "]" + Environment.NewLine
+                                    Else
+                                        ReturnCode = "SKIPPED"
+                                        PatchSummary += "- " + CommandFile + " [" + ReturnCode + "]" + Environment.NewLine
+                                    End If
                                 End If
-                                PatchSummary += "- " + CommandFile + " [Return Code: " + ReturnCode + "]" + Environment.NewLine
                             Next
 
                             For x As Integer = 0 To GetPatchFromManifest(i).DestReplaceList.Count - 1
@@ -438,9 +445,15 @@
                                 If GetPatchFromManifest(i).SysCmdReturnCodes.Count > x Then
                                     ReturnCode = GetPatchFromManifest(i).SysCmdReturnCodes.Item(x)
                                 Else
-                                    ReturnCode = "SKIPPED"
+                                    If GetPatchFromManifest(i).PatchAction = PatchVector.EXECUTE_FAIL OrElse
+                                        GetPatchFromManifest(i).PatchAction = PatchVector.APPLY_FAIL Then
+                                        ReturnCode = "FAILED"
+                                        PatchSummary += "- " + CommandFile + " [" + ReturnCode + "]" + Environment.NewLine
+                                    Else
+                                        ReturnCode = "SKIPPED"
+                                        PatchSummary += "- " + CommandFile + " [" + ReturnCode + "]" + Environment.NewLine
+                                    End If
                                 End If
-                                PatchSummary += "- " + CommandFile + " [Return Code: " + ReturnCode + "]" + Environment.NewLine
                             Next
 
                         End If

--- a/WinOffline/Manifest.vb
+++ b/WinOffline/Manifest.vb
@@ -235,9 +235,7 @@
                 PatchSummary += "No exceptions thrown." + Environment.NewLine
             Else
                 For i As Integer = 0 To ExceptionManifest.Count() - 1
-                    PatchSummary += Environment.NewLine + "Exception #" + ExceptionCounter.ToString + ":" + Environment.NewLine
-                    PatchSummary += "----------------" + Environment.NewLine
-                    PatchSummary += ExceptionManifest.Item(i).ToString + Environment.NewLine
+                    PatchSummary += Environment.NewLine + "Exception #" + ExceptionCounter.ToString + ": " + ExceptionManifest.Item(i).ToString + Environment.NewLine
                     For j As Integer = i + 1 To ExceptionManifest.Count() - 1
                         If ExceptionManifest.Item(j).ToString.Equals("//BREAK//") Then
                             i = j
@@ -246,7 +244,7 @@
                             PatchSummary += ExceptionManifest.Item(j).ToString + Environment.NewLine
                         End If
                     Next
-                    PatchSummary += "----------------" + Environment.NewLine
+                    PatchSummary += Environment.NewLine
                     ExceptionCounter += 1
                 Next
             End If
@@ -304,9 +302,7 @@
                 PatchSummary += "No exceptions thrown." + Environment.NewLine
             Else
                 For i As Integer = 0 To ExceptionManifest.Count() - 1
-                    PatchSummary += Environment.NewLine + "Exception #" + ExceptionCounter.ToString + ":" + Environment.NewLine
-                    PatchSummary += ExceptionManifest.Item(i).ToString + Environment.NewLine
-                    PatchSummary += "----------------" + Environment.NewLine
+                    PatchSummary += Environment.NewLine + "Exception #" + ExceptionCounter.ToString + ": " + ExceptionManifest.Item(i).ToString + Environment.NewLine
                     For j As Integer = i + 1 To ExceptionManifest.Count() - 1
                         If ExceptionManifest.Item(j).ToString.Equals("//BREAK//") Then
                             i = j
@@ -315,7 +311,7 @@
                             PatchSummary += ExceptionManifest.Item(j).ToString + Environment.NewLine
                         End If
                     Next
-                    PatchSummary += "----------------" + Environment.NewLine
+                    PatchSummary += Environment.NewLine
                     ExceptionCounter += 1
                 Next
             End If

--- a/WinOffline/Manifest.vb
+++ b/WinOffline/Manifest.vb
@@ -373,7 +373,9 @@
                         For x As Integer = 0 To GetRemovalFromManifest(i).FileRemovalResult.Count - 1
                             ReplaceFile = GetRemovalFromManifest(i).RemovalFileName.Item(x)
                             PatchSummary += "- " + ReplaceFile + " ["
-                            If GetRemovalFromManifest(i).FileRemovalResult.Item(x) = RemovalVector.FILE_SKIPPED Then
+                            If GetRemovalFromManifest(i).FileRemovalResult.Item(x) = RemovalVector.FILE_REVERSED Then
+                                PatchSummary += "REVERSED]" + Environment.NewLine
+                            ElseIf GetRemovalFromManifest(i).FileRemovalResult.Item(x) = RemovalVector.FILE_SKIPPED Then
                                 PatchSummary += "SKIPPED]" + Environment.NewLine
                             ElseIf GetRemovalFromManifest(i).FileRemovalResult.Item(x) = RemovalVector.FILE_OK Then
                                 PatchSummary += "OK]" + Environment.NewLine

--- a/WinOffline/Manifest.vb
+++ b/WinOffline/Manifest.vb
@@ -301,6 +301,7 @@
             PatchSummary += Environment.NewLine
             If ExceptionManifest.Count = 0 Then
                 PatchSummary += "No exceptions thrown." + Environment.NewLine
+                PatchSummary += Environment.NewLine
             Else
                 For i As Integer = 0 To ExceptionManifest.Count() - 1
                     PatchSummary += "Exception #" + ExceptionCounter.ToString + ": " + ExceptionManifest.Item(i).ToString + Environment.NewLine
@@ -316,7 +317,6 @@
                     ExceptionCounter += 1
                 Next
             End If
-            PatchSummary += Environment.NewLine
             For i As Integer = 0 To Globals.ProcessFriendlyName.Length + 14
                 PatchSummary += "-"
             Next

--- a/WinOffline/Manifest.vb
+++ b/WinOffline/Manifest.vb
@@ -233,6 +233,7 @@
             PatchSummary += Environment.NewLine
             If ExceptionManifest.Count = 0 Then
                 PatchSummary += "No exceptions thrown." + Environment.NewLine
+                PatchSummary += Environment.NewLine
             Else
                 For i As Integer = 0 To ExceptionManifest.Count() - 1
                     PatchSummary += "Exception #" + ExceptionCounter.ToString + ": " + ExceptionManifest.Item(i).ToString + Environment.NewLine
@@ -248,7 +249,7 @@
                     ExceptionCounter += 1
                 Next
             End If
-            PatchSummary += Environment.NewLine
+
             For i As Integer = 0 To Globals.ProcessFriendlyName.Length + 12
                 PatchSummary += "-"
             Next
@@ -389,7 +390,7 @@
                         PatchSummary += GetPatchFromManifest(i).PatchFile.GetFriendlyName + ": "
                         If GetPatchFromManifest(i).PatchAction = PatchVector.UNAVAILABLE Then
                             PatchSummary += "UNAVAILABLE" + Environment.NewLine
-                            PatchSummary += GetPatchFromManifest(i).CommentString.Replace("NEWLINE", Environment.NewLine) + Environment.NewLine
+                            PatchSummary += GetPatchFromManifest(i).CommentString.Replace("NEWLINE", Environment.NewLine)
                         ElseIf GetPatchFromManifest(i).PatchAction = PatchVector.NOT_APPLICABLE Then
                             PatchSummary += "NOT APPLICABLE" + Environment.NewLine
                             PatchSummary += GetPatchFromManifest(i).CommentString.Replace("NEWLINE", Environment.NewLine) + Environment.NewLine
@@ -454,6 +455,7 @@
                                 CommandFile = GetPatchFromManifest(i).GetSysCommandList.Item(x)
                                 If GetPatchFromManifest(i).SysCmdReturnCodes.Count > x Then
                                     ReturnCode = GetPatchFromManifest(i).SysCmdReturnCodes.Item(x)
+                                    PatchSummary += "- " + CommandFile + " [Return Code: " + ReturnCode + "]" + Environment.NewLine
                                 Else
                                     If GetPatchFromManifest(i).PatchAction = PatchVector.EXECUTE_FAIL OrElse
                                         GetPatchFromManifest(i).PatchAction = PatchVector.APPLY_FAIL Then

--- a/WinOffline/Manifest.vb
+++ b/WinOffline/Manifest.vb
@@ -452,6 +452,8 @@
                                     PatchSummary += "REBOOT REQUIRED]" + Environment.NewLine
                                 ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_FAILED Then
                                     PatchSummary += "FAILED]" + Environment.NewLine
+                                ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_UNCHANGED Then
+                                    PatchSummary += "UNCHANGED]" + Environment.NewLine
                                 End If
                             Next
 

--- a/WinOffline/Manifest.vb
+++ b/WinOffline/Manifest.vb
@@ -426,24 +426,16 @@
                                     ReturnCode = GetPatchFromManifest(i).PreCmdReturnCodes.Item(x)
                                     PatchSummary += "- " + CommandFile + " [Return Code: " + ReturnCode + "]" + Environment.NewLine
                                 Else
-                                    If GetPatchFromManifest(i).PatchAction = PatchVector.EXECUTE_FAIL OrElse
-                                        GetPatchFromManifest(i).PatchAction = PatchVector.APPLY_FAIL Then
-                                        ReturnCode = "FAILED"
-                                        PatchSummary += "- " + CommandFile + " [" + ReturnCode + "]" + Environment.NewLine
-                                    Else
-                                        ReturnCode = "SKIPPED"
-                                        PatchSummary += "- " + CommandFile + " [" + ReturnCode + "]" + Environment.NewLine
-                                    End If
+                                    ReturnCode = "NOT EXECUTED"
+                                    PatchSummary += "- " + CommandFile + " [" + ReturnCode + "]" + Environment.NewLine
                                 End If
                             Next
 
                             For x As Integer = 0 To GetPatchFromManifest(i).DestReplaceList.Count - 1
                                 ReplaceFile = GetPatchFromManifest(i).DestReplaceList.Item(x)
                                 PatchSummary += "- " + ReplaceFile + " ["
-                                If GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_REMOVED Then
-                                    PatchSummary += "REMOVED NEW FILE]" + Environment.NewLine
-                                ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_RESTORED Then
-                                    PatchSummary += "RESTORED ORIGINAL FILE]" + Environment.NewLine
+                                If GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_REVERSED Then
+                                    PatchSummary += "REVERSED]" + Environment.NewLine
                                 ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_SKIPPED Then
                                     PatchSummary += "SKIPPED]" + Environment.NewLine
                                 ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_OK Then
@@ -452,8 +444,6 @@
                                     PatchSummary += "REBOOT REQUIRED]" + Environment.NewLine
                                 ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_FAILED Then
                                     PatchSummary += "FAILED]" + Environment.NewLine
-                                ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_UNCHANGED Then
-                                    PatchSummary += "UNCHANGED]" + Environment.NewLine
                                 End If
                             Next
 
@@ -463,14 +453,8 @@
                                     ReturnCode = GetPatchFromManifest(i).SysCmdReturnCodes.Item(x)
                                     PatchSummary += "- " + CommandFile + " [Return Code: " + ReturnCode + "]" + Environment.NewLine
                                 Else
-                                    If GetPatchFromManifest(i).PatchAction = PatchVector.EXECUTE_FAIL OrElse
-                                        GetPatchFromManifest(i).PatchAction = PatchVector.APPLY_FAIL Then
-                                        ReturnCode = "FAILED"
-                                        PatchSummary += "- " + CommandFile + " [" + ReturnCode + "]" + Environment.NewLine
-                                    Else
-                                        ReturnCode = "SKIPPED"
-                                        PatchSummary += "- " + CommandFile + " [" + ReturnCode + "]" + Environment.NewLine
-                                    End If
+                                    ReturnCode = "NOT EXECUTED"
+                                    PatchSummary += "- " + CommandFile + " [" + ReturnCode + "]" + Environment.NewLine
                                 End If
                             Next
 

--- a/WinOffline/Manifest.vb
+++ b/WinOffline/Manifest.vb
@@ -441,9 +441,9 @@
                                 ReplaceFile = GetPatchFromManifest(i).DestReplaceList.Item(x)
                                 PatchSummary += "- " + ReplaceFile + " ["
                                 If GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_REMOVED Then
-                                    PatchSummary += "NEW FILE REMOVED]" + Environment.NewLine
+                                    PatchSummary += "REPLACED OK --> NEW FILE REMOVED]" + Environment.NewLine
                                 ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_RESTORED Then
-                                    PatchSummary += "ORIGINAL RESTORED]" + Environment.NewLine
+                                    PatchSummary += "REPLACED OK --> ORIGINAL FILE RESTORED]" + Environment.NewLine
                                 ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_SKIPPED Then
                                     PatchSummary += "SKIPPED]" + Environment.NewLine
                                 ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_OK Then

--- a/WinOffline/Manifest.vb
+++ b/WinOffline/Manifest.vb
@@ -40,6 +40,7 @@
                 For Each strLine As String In NewItem
                     ExceptionManifest.Add(strLine)
                 Next
+                ExceptionManifest.Add("//BREAK//")
             End If
 
             Return
@@ -107,7 +108,6 @@
                 CacheWriter = New System.IO.StreamWriter(CacheFile, False)
                 For n As Integer = 0 To ExceptionManifest.Count() - 1
                     strLine = ExceptionManifest.Item(n)
-                    Logger.WriteDebug(CallStack, "Write: " + strLine)
                     CacheWriter.WriteLine(strLine)
                 Next
                 Logger.WriteDebug(CallStack, "Close file: " + CacheFile)
@@ -234,11 +234,18 @@
             If ExceptionManifest.Count = 0 Then
                 PatchSummary += "No exceptions thrown." + Environment.NewLine
             Else
-                For i As Integer = 0 To ExceptionManifest.Count() - 2 Step 2
+                For i As Integer = 0 To ExceptionManifest.Count() - 1
                     PatchSummary += Environment.NewLine + "Exception #" + ExceptionCounter.ToString + ":" + Environment.NewLine
                     PatchSummary += "----------------" + Environment.NewLine
                     PatchSummary += ExceptionManifest.Item(i).ToString + Environment.NewLine
-                    PatchSummary += ExceptionManifest.Item(i + 1).ToString + Environment.NewLine
+                    For j As Integer = i + 1 To ExceptionManifest.Count() - 1
+                        If ExceptionManifest.Item(j).ToString.Equals("//BREAK//") Then
+                            i = j
+                            Exit For
+                        Else
+                            PatchSummary += ExceptionManifest.Item(j).ToString + Environment.NewLine
+                        End If
+                    Next
                     PatchSummary += "----------------" + Environment.NewLine
                     ExceptionCounter += 1
                 Next
@@ -296,11 +303,18 @@
             If ExceptionManifest.Count = 0 Then
                 PatchSummary += "No exceptions thrown." + Environment.NewLine
             Else
-                For i As Integer = 0 To ExceptionManifest.Count() - 2 Step 2
+                For i As Integer = 0 To ExceptionManifest.Count() - 1
                     PatchSummary += Environment.NewLine + "Exception #" + ExceptionCounter.ToString + ":" + Environment.NewLine
-                    PatchSummary += "----------------" + Environment.NewLine
                     PatchSummary += ExceptionManifest.Item(i).ToString + Environment.NewLine
-                    PatchSummary += ExceptionManifest.Item(i + 1).ToString + Environment.NewLine
+                    PatchSummary += "----------------" + Environment.NewLine
+                    For j As Integer = i + 1 To ExceptionManifest.Count() - 1
+                        If ExceptionManifest.Item(j).ToString.Equals("//BREAK//") Then
+                            i = j
+                            Exit For
+                        Else
+                            PatchSummary += ExceptionManifest.Item(j).ToString + Environment.NewLine
+                        End If
+                    Next
                     PatchSummary += "----------------" + Environment.NewLine
                     ExceptionCounter += 1
                 Next

--- a/WinOffline/Manifest.vb
+++ b/WinOffline/Manifest.vb
@@ -441,9 +441,9 @@
                                 ReplaceFile = GetPatchFromManifest(i).DestReplaceList.Item(x)
                                 PatchSummary += "- " + ReplaceFile + " ["
                                 If GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_REMOVED Then
-                                    PatchSummary += "REMOVED (NEW FILE)]" + Environment.NewLine
+                                    PatchSummary += "REMOVED NEW FILE]" + Environment.NewLine
                                 ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_RESTORED Then
-                                    PatchSummary += "RESTORED (ORIGINAL FILE)]" + Environment.NewLine
+                                    PatchSummary += "RESTORED ORIGINAL FILE]" + Environment.NewLine
                                 ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_SKIPPED Then
                                     PatchSummary += "SKIPPED]" + Environment.NewLine
                                 ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_OK Then

--- a/WinOffline/Manifest.vb
+++ b/WinOffline/Manifest.vb
@@ -441,9 +441,9 @@
                                 ReplaceFile = GetPatchFromManifest(i).DestReplaceList.Item(x)
                                 PatchSummary += "- " + ReplaceFile + " ["
                                 If GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_REMOVED Then
-                                    PatchSummary += "REPLACED OK --> NEW FILE REMOVED]" + Environment.NewLine
+                                    PatchSummary += "REMOVED (NEW FILE)]" + Environment.NewLine
                                 ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_RESTORED Then
-                                    PatchSummary += "REPLACED OK --> ORIGINAL FILE RESTORED]" + Environment.NewLine
+                                    PatchSummary += "RESTORED (ORIGINAL FILE)]" + Environment.NewLine
                                 ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_SKIPPED Then
                                     PatchSummary += "SKIPPED]" + Environment.NewLine
                                 ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_OK Then

--- a/WinOffline/Manifest.vb
+++ b/WinOffline/Manifest.vb
@@ -377,7 +377,10 @@
                 Else
                     For i As Integer = 0 To PatchManifest.Count - 1
                         PatchSummary += GetPatchFromManifest(i).PatchFile.GetFriendlyName + ": "
-                        If GetPatchFromManifest(i).PatchAction = PatchVector.NOT_APPLICABLE Then
+                        If GetPatchFromManifest(i).PatchAction = PatchVector.UNAVAILABLE Then
+                            PatchSummary += "UNAVAILABLE" + Environment.NewLine
+                            PatchSummary += GetPatchFromManifest(i).CommentString.Replace("NEWLINE", Environment.NewLine) + Environment.NewLine
+                        ElseIf GetPatchFromManifest(i).PatchAction = PatchVector.NOT_APPLICABLE Then
                             PatchSummary += "NOT APPLICABLE" + Environment.NewLine
                             PatchSummary += GetPatchFromManifest(i).CommentString.Replace("NEWLINE", Environment.NewLine) + Environment.NewLine
                         ElseIf GetPatchFromManifest(i).PatchAction = PatchVector.ALREADY_APPLIED Then

--- a/WinOffline/Manifest.vb
+++ b/WinOffline/Manifest.vb
@@ -415,9 +415,9 @@
                         Else
                             PatchSummary += "UNKNOWN" + Environment.NewLine
                         End If
-                        If GetPatchFromManifest(i).PatchAction = PatchVector.APPLY_OK Or
-                            GetPatchFromManifest(i).PatchAction = PatchVector.APPLY_FAIL Or
-                            GetPatchFromManifest(i).PatchAction = PatchVector.EXECUTE_OK Or
+                        If GetPatchFromManifest(i).PatchAction = PatchVector.APPLY_OK OrElse
+                            GetPatchFromManifest(i).PatchAction = PatchVector.APPLY_FAIL OrElse
+                            GetPatchFromManifest(i).PatchAction = PatchVector.EXECUTE_OK OrElse
                             GetPatchFromManifest(i).PatchAction = PatchVector.EXECUTE_FAIL Then
 
                             For x As Integer = 0 To GetPatchFromManifest(i).GetPreCommandList.Count - 1
@@ -440,8 +440,10 @@
                             For x As Integer = 0 To GetPatchFromManifest(i).DestReplaceList.Count - 1
                                 ReplaceFile = GetPatchFromManifest(i).DestReplaceList.Item(x)
                                 PatchSummary += "- " + ReplaceFile + " ["
-                                If GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_REVERSED Then
-                                    PatchSummary += "CHANGES REVERSED]" + Environment.NewLine
+                                If GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_REMOVED Then
+                                    PatchSummary += "NEW FILE REMOVED]" + Environment.NewLine
+                                ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_RESTORED Then
+                                    PatchSummary += "ORIGINAL RESTORED]" + Environment.NewLine
                                 ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_SKIPPED Then
                                     PatchSummary += "SKIPPED]" + Environment.NewLine
                                 ElseIf GetPatchFromManifest(i).FileReplaceResult.Item(x) = PatchVector.FILE_OK Then

--- a/WinOffline/My Project/AssemblyInfo.vb
+++ b/WinOffline/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("2018.10.04")>
-<Assembly: AssemblyFileVersion("2018.10.04")>
+<Assembly: AssemblyVersion("2018.10.11")>
+<Assembly: AssemblyFileVersion("2018.10.11")>

--- a/WinOffline/My Project/AssemblyInfo.vb
+++ b/WinOffline/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("2018.10.11")>
-<Assembly: AssemblyFileVersion("2018.10.11")>
+<Assembly: AssemblyVersion("2018.10.12")>
+<Assembly: AssemblyFileVersion("2018.10.12")>

--- a/WinOffline/My Project/AssemblyInfo.vb
+++ b/WinOffline/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("2018.10.12")>
-<Assembly: AssemblyFileVersion("2018.10.12")>
+<Assembly: AssemblyVersion("2018.10.18")>
+<Assembly: AssemblyFileVersion("2018.10.18")>

--- a/WinOffline/My Project/AssemblyInfo.vb
+++ b/WinOffline/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("2018.10.18")>
-<Assembly: AssemblyFileVersion("2018.10.18")>
+<Assembly: AssemblyVersion("2018.10.19")>
+<Assembly: AssemblyFileVersion("2018.10.19")>

--- a/WinOffline/PatchOperations.vb
+++ b/WinOffline/PatchOperations.vb
@@ -419,7 +419,8 @@
                             If System.IO.File.Exists(DestinationFileName) Then
                                 Logger.WriteDebug(CallStack, "Restore original file: " + DestinationFileName)
                                 Logger.WriteDebug(CallStack, "To: " + pVector.DestReplaceList.Item(y))
-                                System.IO.File.Copy(DestinationFileName, pVector.DestReplaceList.Item(y), True)
+                                System.IO.File.Copy(DestinationFileName, pVector.DestReplaceList.Item(y), True) ' Dangerous copy without try/catch
+                                pVector.FileReplaceResult.Item(y) = PatchVector.FILE_REVERSED
                             End If
                         Next
                     End If
@@ -465,7 +466,8 @@
                         If System.IO.File.Exists(DestinationFileName) Then
                             Logger.WriteDebug(CallStack, "Restore original file: " + DestinationFileName)
                             Logger.WriteDebug(CallStack, "To: " + pVector.DestReplaceList.Item(y))
-                            System.IO.File.Copy(DestinationFileName, pVector.DestReplaceList.Item(y), True)
+                            System.IO.File.Copy(DestinationFileName, pVector.DestReplaceList.Item(y), True) ' Dangerous copy without try/catch
+                            pVector.FileReplaceResult.Item(y) = PatchVector.FILE_REVERSED
                         End If
                     Next
                 End If

--- a/WinOffline/PatchOperations.vb
+++ b/WinOffline/PatchOperations.vb
@@ -497,6 +497,21 @@
             Manifest.UpdateManifest(CallStack, Manifest.EXCEPTION_MANIFEST, {ex.Message, ex.StackTrace})
             Logger.WriteDebug(CallStack, "Patch failed: " + pVector.PatchFile.GetFriendlyName)
             pVector.CommentString = "Reason: Execution of SYSCMD script(s) failed."
+            For y As Integer = 0 To pVector.DestReplaceList.Count - 1 ' Script failure, unfo the file replacements to reverse patch
+                Logger.WriteDebug(CallStack, "Delete replacement file: " + pVector.DestReplaceList.Item(y))
+                System.IO.File.Delete(pVector.DestReplaceList.Item(y))
+                DestinationFileName = ReplacedFolder + "\" + pVector.ReplaceSubFolder.Item(y) + "\" + FileVector.GetShortName(pVector.DestReplaceList.Item(y))
+                DestinationFileName = DestinationFileName.Replace("\\", "\")
+                ' Verify the file exists
+                ' Note: In the case where the patch file is a new file, then nothing was
+                '       backed up to the REPLACED folder, to restore to the original path.
+                If System.IO.File.Exists(DestinationFileName) Then
+                    Logger.WriteDebug(CallStack, "Restore original file: " + DestinationFileName)
+                    Logger.WriteDebug(CallStack, "To: " + pVector.DestReplaceList.Item(y))
+                    System.IO.File.Copy(DestinationFileName, pVector.DestReplaceList.Item(y), True) ' Dangerous copy without try/catch
+                    pVector.FileReplaceResult.Item(y) = PatchVector.FILE_REVERSED
+                End If
+            Next
             Return 10
         End Try
 

--- a/WinOffline/PatchOperations.vb
+++ b/WinOffline/PatchOperations.vb
@@ -64,7 +64,7 @@
                             Manifest.GetPatchFromManifest(i).PatchAction = PatchVector.SKIPPED
                             Manifest.GetPatchFromManifest(i).CommentString = "Reason: This is a simulation."
                         End If
-                    ElseIf Not System.IO.File.Exists(Manifest.GetPatchFromManifest(i).PatchFile.GetFileName) Then
+                    ElseIf Not System.IO.Directory.Exists(Manifest.GetPatchFromManifest(i).PatchFile.GetFilePath) Then
                         Logger.WriteDebug(CallStack, "Result: UNAVAILABLE.")
                         Manifest.GetPatchFromManifest(i).PatchAction = PatchVector.UNAVAILABLE
                         Manifest.GetPatchFromManifest(i).CommentString = "Reason: Patch file [" + Manifest.GetPatchFromManifest(i).PatchFile.GetShortName + "] missing from [" + Manifest.GetPatchFromManifest(i).PatchFile.GetFilePath + "] folder.NEWLINE"
@@ -151,40 +151,36 @@
 
         ' Run PRESYSCMD sripts
         For Each strLine As String In pVector.GetPreCommandList
-            Try
-                ExecutionString = pVector.PatchFile.GetFilePath + "\" + strLine
-                Logger.WriteDebug(CallStack, "Execute pre-script: " + ExecutionString)
+            ExecutionString = pVector.PatchFile.GetFilePath + "\" + strLine
+            Logger.WriteDebug(CallStack, "Execute pre-script: " + ExecutionString)
 
-                ProcessStartInfo = New ProcessStartInfo(ExecutionString)
-                ProcessStartInfo.WorkingDirectory = pVector.PatchFile.GetFilePath
-                ProcessStartInfo.UseShellExecute = False
-                ProcessStartInfo.RedirectStandardOutput = True
-                ProcessStartInfo.CreateNoWindow = True
-                StandardOutput = ""
-                RemainingOutput = ""
-                Logger.WriteDebug("------------------------------------------------------------")
+            ProcessStartInfo = New ProcessStartInfo(ExecutionString)
+            ProcessStartInfo.WorkingDirectory = pVector.PatchFile.GetFilePath
+            ProcessStartInfo.UseShellExecute = False
+            ProcessStartInfo.RedirectStandardOutput = True
+            ProcessStartInfo.CreateNoWindow = True
+            StandardOutput = ""
+            RemainingOutput = ""
+            Logger.WriteDebug("------------------------------------------------------------")
 
-                RunningProcess = Process.Start(ProcessStartInfo)
+            RunningProcess = Process.Start(ProcessStartInfo)
 
-                While RunningProcess.HasExited = False
-                    ConsoleOutput = RunningProcess.StandardOutput.ReadLine
-                    Logger.WriteDebug(ConsoleOutput)
-                    StandardOutput += ConsoleOutput + Environment.NewLine
-                End While
+            While RunningProcess.HasExited = False
+                ConsoleOutput = RunningProcess.StandardOutput.ReadLine
+                Logger.WriteDebug(ConsoleOutput)
+                StandardOutput += ConsoleOutput + Environment.NewLine
+            End While
 
-                RunningProcess.WaitForExit()
-                RemainingOutput = RunningProcess.StandardOutput.ReadToEnd.ToString
-                StandardOutput += RemainingOutput
+            RunningProcess.WaitForExit()
+            RemainingOutput = RunningProcess.StandardOutput.ReadToEnd.ToString
+            StandardOutput += RemainingOutput
 
-                Logger.WriteDebug(RemainingOutput)
-                Logger.WriteDebug("------------------------------------------------------------")
-                Logger.WriteDebug(CallStack, "Exit code: " + RunningProcess.ExitCode.ToString)
+            Logger.WriteDebug(RemainingOutput)
+            Logger.WriteDebug("------------------------------------------------------------")
+            Logger.WriteDebug(CallStack, "Exit code: " + RunningProcess.ExitCode.ToString)
 
-                pVector.PreCmdReturnCodes.Add(RunningProcess.ExitCode.ToString)
-                RunningProcess.Close()
-            Catch ex As Exception
-                Throw ex ' Continue exception
-            End Try
+            pVector.PreCmdReturnCodes.Add(RunningProcess.ExitCode.ToString)
+            RunningProcess.Close()
         Next
 
     End Sub
@@ -200,40 +196,36 @@
 
         ' Run SYSCMD sripts
         For Each strLine As String In pVector.GetSysCommandList
-            Try
-                ExecutionString = pVector.PatchFile.GetFilePath + "\" + strLine
-                Logger.WriteDebug(CallStack, "Execute script: " + ExecutionString)
+            ExecutionString = pVector.PatchFile.GetFilePath + "\" + strLine
+            Logger.WriteDebug(CallStack, "Execute script: " + ExecutionString)
 
-                ProcessStartInfo = New ProcessStartInfo(ExecutionString)
-                ProcessStartInfo.WorkingDirectory = pVector.PatchFile.GetFilePath
-                ProcessStartInfo.UseShellExecute = False
-                ProcessStartInfo.RedirectStandardOutput = True
-                ProcessStartInfo.CreateNoWindow = True
-                StandardOutput = ""
-                RemainingOutput = ""
-                Logger.WriteDebug("------------------------------------------------------------")
+            ProcessStartInfo = New ProcessStartInfo(ExecutionString)
+            ProcessStartInfo.WorkingDirectory = pVector.PatchFile.GetFilePath
+            ProcessStartInfo.UseShellExecute = False
+            ProcessStartInfo.RedirectStandardOutput = True
+            ProcessStartInfo.CreateNoWindow = True
+            StandardOutput = ""
+            RemainingOutput = ""
+            Logger.WriteDebug("------------------------------------------------------------")
 
-                RunningProcess = Process.Start(ProcessStartInfo)
+            RunningProcess = Process.Start(ProcessStartInfo)
 
-                While RunningProcess.HasExited = False
-                    ConsoleOutput = RunningProcess.StandardOutput.ReadLine
-                    Logger.WriteDebug(ConsoleOutput)
-                    StandardOutput += ConsoleOutput + Environment.NewLine
-                End While
+            While RunningProcess.HasExited = False
+                ConsoleOutput = RunningProcess.StandardOutput.ReadLine
+                Logger.WriteDebug(ConsoleOutput)
+                StandardOutput += ConsoleOutput + Environment.NewLine
+            End While
 
-                RunningProcess.WaitForExit()
-                RemainingOutput = RunningProcess.StandardOutput.ReadToEnd.ToString
-                StandardOutput += RemainingOutput
+            RunningProcess.WaitForExit()
+            RemainingOutput = RunningProcess.StandardOutput.ReadToEnd.ToString
+            StandardOutput += RemainingOutput
 
-                Logger.WriteDebug(RemainingOutput)
-                Logger.WriteDebug("------------------------------------------------------------")
-                Logger.WriteDebug(CallStack, "Exit code: " + RunningProcess.ExitCode.ToString)
+            Logger.WriteDebug(RemainingOutput)
+            Logger.WriteDebug("------------------------------------------------------------")
+            Logger.WriteDebug(CallStack, "Exit code: " + RunningProcess.ExitCode.ToString)
 
-                pVector.SysCmdReturnCodes.Add(RunningProcess.ExitCode.ToString)
-                RunningProcess.Close()
-            Catch ex As Exception
-                Throw ex ' Continue exception
-            End Try
+            pVector.SysCmdReturnCodes.Add(RunningProcess.ExitCode.ToString)
+            RunningProcess.Close()
         Next
 
     End Sub

--- a/WinOffline/PatchOperations.vb
+++ b/WinOffline/PatchOperations.vb
@@ -514,6 +514,7 @@
         Dim RemovalMatchFound As Boolean = False
         Dim OriginalFilesFound As Boolean = False
         Dim ReplacedFolder As String = ""
+        Dim BackoutFolder As String = ""
         Dim ReplacedBaseFolder As String = ""
         Dim LatestReplacedFolder As String = ""
         Dim ReplacedIncrement As Integer = 0
@@ -578,6 +579,8 @@
             ReplacedFolder = Globals.EGCFolder + "REPLACED\" + hVector.GetPatchName
             rVector.HistoryFile = Globals.EGCFolder + Globals.HostName + ".his"
         End If
+
+        BackoutFolder = ReplacedFolder + "BACKOUT.OLD"
         LatestReplacedFolder = ReplacedFolder + ".OLD"
 
         If System.IO.Directory.Exists(ReplacedFolder + ".OLD") Then
@@ -794,6 +797,9 @@
         ' Remove REPLACED folder
         Logger.WriteDebug(CallStack, "Delete REPLACED subfolder: " + ReplacedFolder)
         Utility.DeleteFolder(CallStack, ReplacedFolder)
+
+        ' Remove an empty BACKOUT.OLD folder
+        If Utility.IsFolderEmpty(BackoutFolder) Then Utility.DeleteFolder(CallStack, BackoutFolder)
 
         Return 0
 

--- a/WinOffline/PatchOperations.vb
+++ b/WinOffline/PatchOperations.vb
@@ -420,7 +420,7 @@
                                 Logger.WriteDebug(CallStack, "Restore original file: " + DestinationFileName)
                                 Logger.WriteDebug(CallStack, "To: " + pVector.DestReplaceList.Item(y))
                                 System.IO.File.Copy(DestinationFileName, pVector.DestReplaceList.Item(y), True) ' Dangerous copy without try/catch
-                                pVector.FileReplaceResult.Item(y) = PatchVector.FILE_REVERSED
+                                pVector.FileReplaceResult.Item(y) = PatchVector.FILE_RESTORED
                             End If
                         Next
                     End If
@@ -456,18 +456,21 @@
                 Manifest.UpdateManifest(CallStack, Manifest.EXCEPTION_MANIFEST, {ex.Message, ex.StackTrace})
                 If x >= 0 Then ' Undo changes
                     For y As Integer = 0 To pVector.DestReplaceList.Count - 1
-                        Logger.WriteDebug(CallStack, "Delete replacement file: " + pVector.DestReplaceList.Item(y))
-                        System.IO.File.Delete(pVector.DestReplaceList.Item(y))
-                        DestinationFileName = ReplacedFolder + "\" + pVector.ReplaceSubFolder.Item(y) + "\" + FileVector.GetShortName(pVector.DestReplaceList.Item(y))
-                        DestinationFileName = DestinationFileName.Replace("\\", "\")
-                        ' Verify the file exists
-                        ' Note: In the case where the patch file is a new file, then nothing was
-                        '       backed up to the REPLACED folder, to restore to the original path.
-                        If System.IO.File.Exists(DestinationFileName) Then
-                            Logger.WriteDebug(CallStack, "Restore original file: " + DestinationFileName)
-                            Logger.WriteDebug(CallStack, "To: " + pVector.DestReplaceList.Item(y))
-                            System.IO.File.Copy(DestinationFileName, pVector.DestReplaceList.Item(y), True) ' Dangerous copy without try/catch
-                            pVector.FileReplaceResult.Item(y) = PatchVector.FILE_REVERSED
+                        If Not pVector.FileReplaceResult.Item(y) = PatchVector.SKIPPED Then
+                            Logger.WriteDebug(CallStack, "Delete replacement file: " + pVector.DestReplaceList.Item(y))
+                            System.IO.File.Delete(pVector.DestReplaceList.Item(y))
+                            pVector.FileReplaceResult.Item(y) = PatchVector.FILE_REMOVED
+                            DestinationFileName = ReplacedFolder + "\" + pVector.ReplaceSubFolder.Item(y) + "\" + FileVector.GetShortName(pVector.DestReplaceList.Item(y))
+                            DestinationFileName = DestinationFileName.Replace("\\", "\")
+                            ' Verify the file exists
+                            ' Note: In the case where the patch file is a new file, then nothing was
+                            '       backed up to the REPLACED folder, to restore to the original path.
+                            If System.IO.File.Exists(DestinationFileName) Then
+                                Logger.WriteDebug(CallStack, "Restore original file: " + DestinationFileName)
+                                Logger.WriteDebug(CallStack, "To: " + pVector.DestReplaceList.Item(y))
+                                System.IO.File.Copy(DestinationFileName, pVector.DestReplaceList.Item(y), True) ' Dangerous copy without try/catch
+                                pVector.FileReplaceResult.Item(y) = PatchVector.FILE_RESTORED
+                            End If
                         End If
                     Next
                 End If
@@ -497,19 +500,22 @@
             Manifest.UpdateManifest(CallStack, Manifest.EXCEPTION_MANIFEST, {ex.Message, ex.StackTrace})
             Logger.WriteDebug(CallStack, "Patch failed: " + pVector.PatchFile.GetFriendlyName)
             pVector.CommentString = "Reason: Execution of SYSCMD script(s) failed."
-            For y As Integer = 0 To pVector.DestReplaceList.Count - 1 ' Script failure, unfo the file replacements to reverse patch
-                Logger.WriteDebug(CallStack, "Delete replacement file: " + pVector.DestReplaceList.Item(y))
-                System.IO.File.Delete(pVector.DestReplaceList.Item(y))
-                DestinationFileName = ReplacedFolder + "\" + pVector.ReplaceSubFolder.Item(y) + "\" + FileVector.GetShortName(pVector.DestReplaceList.Item(y))
-                DestinationFileName = DestinationFileName.Replace("\\", "\")
-                ' Verify the file exists
-                ' Note: In the case where the patch file is a new file, then nothing was
-                '       backed up to the REPLACED folder, to restore to the original path.
-                If System.IO.File.Exists(DestinationFileName) Then
-                    Logger.WriteDebug(CallStack, "Restore original file: " + DestinationFileName)
-                    Logger.WriteDebug(CallStack, "To: " + pVector.DestReplaceList.Item(y))
-                    System.IO.File.Copy(DestinationFileName, pVector.DestReplaceList.Item(y), True) ' Dangerous copy without try/catch
-                    pVector.FileReplaceResult.Item(y) = PatchVector.FILE_REVERSED
+            For y As Integer = 0 To pVector.DestReplaceList.Count - 1 ' Script failure, undo the file replacements to reverse patch
+                If Not pVector.FileReplaceResult.Item(y) = PatchVector.SKIPPED Then
+                    Logger.WriteDebug(CallStack, "Delete replacement file: " + pVector.DestReplaceList.Item(y))
+                    System.IO.File.Delete(pVector.DestReplaceList.Item(y))
+                    pVector.FileReplaceResult.Item(y) = PatchVector.FILE_REMOVED
+                    DestinationFileName = ReplacedFolder + "\" + pVector.ReplaceSubFolder.Item(y) + "\" + FileVector.GetShortName(pVector.DestReplaceList.Item(y))
+                    DestinationFileName = DestinationFileName.Replace("\\", "\")
+                    ' Verify the file exists
+                    ' Note: In the case where the patch file is a new file, then nothing was
+                    '       backed up to the REPLACED folder, to restore to the original path.
+                    If System.IO.File.Exists(DestinationFileName) Then
+                        Logger.WriteDebug(CallStack, "Restore original file: " + DestinationFileName)
+                        Logger.WriteDebug(CallStack, "To: " + pVector.DestReplaceList.Item(y))
+                        System.IO.File.Copy(DestinationFileName, pVector.DestReplaceList.Item(y), True) ' Dangerous copy without try/catch
+                        pVector.FileReplaceResult.Item(y) = PatchVector.FILE_RESTORED
+                    End If
                 End If
             Next
             Return 10

--- a/WinOffline/PatchOperations.vb
+++ b/WinOffline/PatchOperations.vb
@@ -733,6 +733,8 @@
                     Else
                         Logger.WriteDebug(CallStack, "Delete current file: " + hVector.GetInstalledFiles.Item(x))
                         Utility.DeleteFile(CallStack, hVector.GetInstalledFiles.Item(x))
+                        rVector.RemovalFileName.Add(hVector.GetInstalledFiles.Item(x))
+                        rVector.FileRemovalResult.Add(RemovalVector.FILE_OK)
                     End If
                 Catch ex As Exception
                     Logger.WriteDebug(CallStack, "Error: Failed to delete current file(s), or schedule their removal.")

--- a/WinOffline/PatchOperations.vb
+++ b/WinOffline/PatchOperations.vb
@@ -20,7 +20,6 @@
                             Manifest.GetRemovalFromManifest(i).RemovalAction = RemovalVector.REMOVAL_FAIL
                             Manifest.GetRemovalFromManifest(i).CommentString = "Reason: This is a patch error simulation."
                         Else
-
                             Logger.WriteDebug(CallStack, "Switch: Simulate removing patch.")
                             Manifest.GetRemovalFromManifest(i).RemovalAction = RemovalVector.SKIPPED
                             Manifest.GetRemovalFromManifest(i).CommentString = "Reason: This is a simulation."
@@ -54,6 +53,7 @@
                 For i As Integer = 0 To Manifest.PatchManifestCount - 1
                     Logger.WriteDebug(CallStack, "Read patch manifest index: [" + i.ToString() + "]")
                     Logger.WriteDebug(CallStack, "Patch file: " + Manifest.GetPatchFromManifest(i).PatchFile.GetFileName)
+
                     If Globals.SimulatePatchSwitch Then
                         If Globals.SimulatePatchErrorSwitch Then
                             Logger.WriteDebug(CallStack, "Switch: Simulate patching error.")
@@ -64,6 +64,10 @@
                             Manifest.GetPatchFromManifest(i).PatchAction = PatchVector.SKIPPED
                             Manifest.GetPatchFromManifest(i).CommentString = "Reason: This is a simulation."
                         End If
+                    ElseIf Not System.IO.File.Exists(Manifest.GetPatchFromManifest(i).PatchFile.GetFileName) Then
+                        Logger.WriteDebug(CallStack, "Result: UNAVAILABLE.")
+                        Manifest.GetPatchFromManifest(i).PatchAction = PatchVector.UNAVAILABLE
+                        Manifest.GetPatchFromManifest(i).CommentString = "Reason: Patch file [" + Manifest.GetPatchFromManifest(i).PatchFile.GetShortName + "] missing from [" + Manifest.GetPatchFromManifest(i).PatchFile.GetFilePath + "] folder.NEWLINE"
                     ElseIf Not Manifest.GetPatchFromManifest(i).GetInstruction("VERSIONCHECK").Equals("") AndAlso
                         Not Manifest.GetPatchFromManifest(i).GetInstruction("VERSIONCHECK").Equals(Globals.ITCMComstoreVersion) Then
                         Logger.WriteDebug(CallStack, "Result: SKIPPED.")
@@ -147,36 +151,40 @@
 
         ' Run PRESYSCMD sripts
         For Each strLine As String In pVector.GetPreCommandList
-            ExecutionString = pVector.PatchFile.GetFilePath + "\" + strLine
-            Logger.WriteDebug(CallStack, "Execute pre-script: " + ExecutionString)
+            Try
+                ExecutionString = pVector.PatchFile.GetFilePath + "\" + strLine
+                Logger.WriteDebug(CallStack, "Execute pre-script: " + ExecutionString)
 
-            ProcessStartInfo = New ProcessStartInfo(ExecutionString)
-            ProcessStartInfo.WorkingDirectory = pVector.PatchFile.GetFilePath
-            ProcessStartInfo.UseShellExecute = False
-            ProcessStartInfo.RedirectStandardOutput = True
-            ProcessStartInfo.CreateNoWindow = True
-            StandardOutput = ""
-            RemainingOutput = ""
-            Logger.WriteDebug("------------------------------------------------------------")
+                ProcessStartInfo = New ProcessStartInfo(ExecutionString)
+                ProcessStartInfo.WorkingDirectory = pVector.PatchFile.GetFilePath
+                ProcessStartInfo.UseShellExecute = False
+                ProcessStartInfo.RedirectStandardOutput = True
+                ProcessStartInfo.CreateNoWindow = True
+                StandardOutput = ""
+                RemainingOutput = ""
+                Logger.WriteDebug("------------------------------------------------------------")
 
-            RunningProcess = Process.Start(ProcessStartInfo)
+                RunningProcess = Process.Start(ProcessStartInfo)
 
-            While RunningProcess.HasExited = False
-                ConsoleOutput = RunningProcess.StandardOutput.ReadLine
-                Logger.WriteDebug(ConsoleOutput)
-                StandardOutput += ConsoleOutput + Environment.NewLine
-            End While
+                While RunningProcess.HasExited = False
+                    ConsoleOutput = RunningProcess.StandardOutput.ReadLine
+                    Logger.WriteDebug(ConsoleOutput)
+                    StandardOutput += ConsoleOutput + Environment.NewLine
+                End While
 
-            RunningProcess.WaitForExit()
-            RemainingOutput = RunningProcess.StandardOutput.ReadToEnd.ToString
-            StandardOutput += RemainingOutput
+                RunningProcess.WaitForExit()
+                RemainingOutput = RunningProcess.StandardOutput.ReadToEnd.ToString
+                StandardOutput += RemainingOutput
 
-            Logger.WriteDebug(RemainingOutput)
-            Logger.WriteDebug("------------------------------------------------------------")
-            Logger.WriteDebug(CallStack, "Exit code: " + RunningProcess.ExitCode.ToString)
+                Logger.WriteDebug(RemainingOutput)
+                Logger.WriteDebug("------------------------------------------------------------")
+                Logger.WriteDebug(CallStack, "Exit code: " + RunningProcess.ExitCode.ToString)
 
-            pVector.PreCmdReturnCodes.Add(RunningProcess.ExitCode.ToString)
-            RunningProcess.Close()
+                pVector.PreCmdReturnCodes.Add(RunningProcess.ExitCode.ToString)
+                RunningProcess.Close()
+            Catch ex As Exception
+                Throw ex ' Continue exception
+            End Try
         Next
 
     End Sub
@@ -192,36 +200,40 @@
 
         ' Run SYSCMD sripts
         For Each strLine As String In pVector.GetSysCommandList
-            ExecutionString = pVector.PatchFile.GetFilePath + "\" + strLine
-            Logger.WriteDebug(CallStack, "Execute script: " + ExecutionString)
+            Try
+                ExecutionString = pVector.PatchFile.GetFilePath + "\" + strLine
+                Logger.WriteDebug(CallStack, "Execute script: " + ExecutionString)
 
-            ProcessStartInfo = New ProcessStartInfo(ExecutionString)
-            ProcessStartInfo.WorkingDirectory = pVector.PatchFile.GetFilePath
-            ProcessStartInfo.UseShellExecute = False
-            ProcessStartInfo.RedirectStandardOutput = True
-            ProcessStartInfo.CreateNoWindow = True
-            StandardOutput = ""
-            RemainingOutput = ""
-            Logger.WriteDebug("------------------------------------------------------------")
+                ProcessStartInfo = New ProcessStartInfo(ExecutionString)
+                ProcessStartInfo.WorkingDirectory = pVector.PatchFile.GetFilePath
+                ProcessStartInfo.UseShellExecute = False
+                ProcessStartInfo.RedirectStandardOutput = True
+                ProcessStartInfo.CreateNoWindow = True
+                StandardOutput = ""
+                RemainingOutput = ""
+                Logger.WriteDebug("------------------------------------------------------------")
 
-            RunningProcess = Process.Start(ProcessStartInfo)
+                RunningProcess = Process.Start(ProcessStartInfo)
 
-            While RunningProcess.HasExited = False
-                ConsoleOutput = RunningProcess.StandardOutput.ReadLine
-                Logger.WriteDebug(ConsoleOutput)
-                StandardOutput += ConsoleOutput + Environment.NewLine
-            End While
+                While RunningProcess.HasExited = False
+                    ConsoleOutput = RunningProcess.StandardOutput.ReadLine
+                    Logger.WriteDebug(ConsoleOutput)
+                    StandardOutput += ConsoleOutput + Environment.NewLine
+                End While
 
-            RunningProcess.WaitForExit()
-            RemainingOutput = RunningProcess.StandardOutput.ReadToEnd.ToString
-            StandardOutput += RemainingOutput
+                RunningProcess.WaitForExit()
+                RemainingOutput = RunningProcess.StandardOutput.ReadToEnd.ToString
+                StandardOutput += RemainingOutput
 
-            Logger.WriteDebug(RemainingOutput)
-            Logger.WriteDebug("------------------------------------------------------------")
-            Logger.WriteDebug(CallStack, "Exit code: " + RunningProcess.ExitCode.ToString)
+                Logger.WriteDebug(RemainingOutput)
+                Logger.WriteDebug("------------------------------------------------------------")
+                Logger.WriteDebug(CallStack, "Exit code: " + RunningProcess.ExitCode.ToString)
 
-            pVector.SysCmdReturnCodes.Add(RunningProcess.ExitCode.ToString)
-            RunningProcess.Close()
+                pVector.SysCmdReturnCodes.Add(RunningProcess.ExitCode.ToString)
+                RunningProcess.Close()
+            Catch ex As Exception
+                Throw ex ' Continue exception
+            End Try
         Next
 
     End Sub
@@ -294,7 +306,17 @@
         End If
 
         ' Run PRESYSCMD sripts
-        ExecutePreCmd(CallStack, pVector)
+        Try
+            ExecutePreCmd(CallStack, pVector)
+        Catch ex As Exception
+            Logger.WriteDebug(CallStack, "Error: Execution of PRESYSCMD script(s) failed.")
+            Logger.WriteDebug(ex.Message)
+            Logger.WriteDebug(ex.StackTrace)
+            Manifest.UpdateManifest(CallStack, Manifest.EXCEPTION_MANIFEST, {ex.Message, ex.StackTrace})
+            Logger.WriteDebug(CallStack, "Patch failed: " + pVector.PatchFile.GetFriendlyName)
+            pVector.CommentString = "Reason: Execution of PRESYSCMD script(s) failed."
+            Return 4
+        End Try
 
         ' Prepare REPLACED subfolder
         If pVector.SourceReplaceList.Count > 0 Then
@@ -314,9 +336,8 @@
                             Logger.WriteDebug(ex.StackTrace)
                             Manifest.UpdateManifest(CallStack, Manifest.EXCEPTION_MANIFEST, {ex.Message, ex.StackTrace})
                             Logger.WriteDebug(CallStack, "Patch skipped: " + pVector.PatchFile.GetFriendlyName)
-                            Logger.WriteDebug(CallStack, "Reason: Failed to create REPLACED subfolder.")
                             pVector.CommentString = "Reason: Failed to create REPLACED subfolder."
-                            Return 4
+                            Return 5
                         End Try
                     End If
                 End While
@@ -331,9 +352,8 @@
                     Logger.WriteDebug(ex.StackTrace)
                     Manifest.UpdateManifest(CallStack, Manifest.EXCEPTION_MANIFEST, {ex.Message, ex.StackTrace})
                     Logger.WriteDebug(CallStack, "Patch skipped: " + pVector.PatchFile.GetFriendlyName)
-                    Logger.WriteDebug(CallStack, "Reason: Failed to create REPLACED subfolder.")
                     pVector.CommentString = "Reason: Failed to create REPLACED subfolder."
-                    Return 5
+                    Return 6
                 End Try
             End If
         End If
@@ -360,9 +380,8 @@
                     System.IO.Directory.Delete(ReplacedFolder, True)
                     pVector.FileReplaceResult.Item(x) = PatchVector.FILE_FAILED
                     Logger.WriteDebug(CallStack, "Patch failed: " + pVector.PatchFile.GetFriendlyName)
-                    Logger.WriteDebug(CallStack, "Reason: Failed to save original file(s).")
                     pVector.CommentString = "Reason: Failed to save original file(s)."
-                    Return 6
+                    Return 7
                 End Try
             Else
                 ' Add to new file list (We may need to skip replacing these new files later)
@@ -398,7 +417,7 @@
                     Logger.WriteDebug(ex.Message)
                     Logger.WriteDebug(ex.StackTrace)
                     Manifest.UpdateManifest(CallStack, Manifest.EXCEPTION_MANIFEST, {ex.Message, ex.StackTrace})
-                    If x > 0 Then ' Undo changes
+                    If x >= 0 Then ' Undo changes
                         For y As Integer = 0 To pVector.DestReplaceList.Count - 1
                             DestinationFileName = ReplacedFolder + "\" + pVector.ReplaceSubFolder.Item(y) + "\" + FileVector.GetShortName(pVector.DestReplaceList.Item(y))
                             DestinationFileName = DestinationFileName.Replace("\\", "\")
@@ -416,9 +435,8 @@
                     System.IO.Directory.Delete(ReplacedFolder, True)
                     pVector.FileReplaceResult.Item(x) = PatchVector.FILE_FAILED
                     Logger.WriteDebug(CallStack, "Patch failed: " + pVector.PatchFile.GetFriendlyName)
-                    Logger.WriteDebug(CallStack, "Reason: Failed to delete original file(s), or schedule their removal.")
                     pVector.CommentString = "Reason: Failed to delete original file(s), or schedule their removal."
-                    Return 7
+                    Return 8
                 End Try
             End If
         Next
@@ -443,7 +461,7 @@
                 Logger.WriteDebug(ex.Message)
                 Logger.WriteDebug(ex.StackTrace)
                 Manifest.UpdateManifest(CallStack, Manifest.EXCEPTION_MANIFEST, {ex.Message, ex.StackTrace})
-                If x > 0 Then ' Undo changes
+                If x >= 0 Then ' Undo changes
                     For y As Integer = 0 To pVector.DestReplaceList.Count - 1
                         Logger.WriteDebug(CallStack, "Delete replacement file: " + pVector.DestReplaceList.Item(y))
                         System.IO.File.Delete(pVector.DestReplaceList.Item(y))
@@ -463,9 +481,8 @@
                 System.IO.Directory.Delete(ReplacedFolder, True)
                 pVector.FileReplaceResult.Item(x) = PatchVector.FILE_FAILED
                 Logger.WriteDebug(CallStack, "Patch failed: " + pVector.PatchFile.GetFriendlyName)
-                Logger.WriteDebug(CallStack, "Reason: Failed to copy replacement file(s) to destination.")
                 pVector.CommentString = "Reason: Failed to copy replacement file(s) to destination."
-                Return 8
+                Return 9
             End Try
         Next
 
@@ -477,7 +494,17 @@
         End If
 
         ' Run SYSCMD sripts
-        ExecutePostCmd(CallStack, pVector)
+        Try
+            ExecutePostCmd(CallStack, pVector)
+        Catch ex As Exception
+            Logger.WriteDebug(CallStack, "Error: Execution of SYSCMD script(s) failed.")
+            Logger.WriteDebug(ex.Message)
+            Logger.WriteDebug(ex.StackTrace)
+            Manifest.UpdateManifest(CallStack, Manifest.EXCEPTION_MANIFEST, {ex.Message, ex.StackTrace})
+            Logger.WriteDebug(CallStack, "Patch failed: " + pVector.PatchFile.GetFriendlyName)
+            pVector.CommentString = "Reason: Execution of SYSCMD script(s) failed."
+            Return 10
+        End Try
 
         Return 0
 

--- a/WinOffline/PatchVector.vb
+++ b/WinOffline/PatchVector.vb
@@ -14,6 +14,7 @@
         Private _ReplaceFolder As String                    ' Replacement location folder for storing original files.
         Private _ReplaceSubFolder As New ArrayList          ' Sub folder within replacement folder, for storing each original file.
         Private _SkipIfNotFoundList As New ArrayList        ' File replacements to skip, if destination file is not originally present (i.e. source file is new).
+        Public Const UNAVAILABLE As Integer = -5            ' Apply action code: Unavailable. (JCL is missing from TEMP)
         Public Const NOT_APPLICABLE As Integer = -4         ' Apply action code: Not applicable.
         Public Const ALREADY_APPLIED As Integer = -3        ' Apply action code: Already applied.
         Public Const NO_ACTION As Integer = -2              ' Apply action code: No action.

--- a/WinOffline/PatchVector.vb
+++ b/WinOffline/PatchVector.vb
@@ -14,7 +14,7 @@
         Private _ReplaceFolder As String                    ' Replacement location folder for storing original files.
         Private _ReplaceSubFolder As New ArrayList          ' Sub folder within replacement folder, for storing each original file.
         Private _SkipIfNotFoundList As New ArrayList        ' File replacements to skip, if destination file is not originally present (i.e. source file is new).
-        Public Const UNAVAILABLE As Integer = -5            ' Apply action code: Unavailable. (JCL is missing from TEMP)
+        Public Const UNAVAILABLE As Integer = -5            ' Apply action code: Unavailable. (Files are missing)
         Public Const NOT_APPLICABLE As Integer = -4         ' Apply action code: Not applicable.
         Public Const ALREADY_APPLIED As Integer = -3        ' Apply action code: Already applied.
         Public Const NO_ACTION As Integer = -2              ' Apply action code: No action.

--- a/WinOffline/PatchVector.vb
+++ b/WinOffline/PatchVector.vb
@@ -29,6 +29,7 @@
         Public Const FILE_OK As Integer = 0                 ' File replacement code: File ok.
         Public Const FILE_REBOOT_REQUIRED As Integer = 1    ' File replacement code: Reboot required.
         Public Const FILE_FAILED As Integer = 2             ' File replacement code: File fail.
+        Public Const FILE_UNCHANGED As Integer = 3          ' File replacement code: Unchanged.
         Private ClientAutoProductCodes = New ArrayList({"BITCM", "DTSVMG", "DTMGSU", "TNGAMO", "TNGSDO", "TNGRCO"})
         Private SharedComponentProductCodes As New ArrayList({"DTMINF"})
         Private CAMProductCodes As New ArrayList({"CCSCAM", "TNGCAM"})
@@ -48,7 +49,7 @@
 
             For Each ReplacedFile As String In GetShortNameReplaceList()
                 _SourceReplaceList.Add(_FileName.GetFilePath + "\" + ReplacedFile)
-                _FileReplaceResult.Add(-1)
+                _FileReplaceResult.Add(FILE_UNCHANGED)
             Next
 
             For Each ReplacedFile As String In GetRawReplaceList()

--- a/WinOffline/PatchVector.vb
+++ b/WinOffline/PatchVector.vb
@@ -23,7 +23,8 @@
         Public Const APPLY_FAIL As Integer = 1              ' Apply action code: Apply fail.
         Public Const EXECUTE_OK As Integer = 2              ' Apply action code: Execute ok.
         Public Const EXECUTE_FAIL As Integer = 3            ' Apply action code: Execute fail.
-        Public Const FILE_REVERSED As Integer = -2          ' File replacement code: Changes reversed.
+        Public Const FILE_REMOVED As Integer = -3           ' File replacement code: New file removed.
+        Public Const FILE_RESTORED As Integer = -2          ' File replacement code: Original restored.
         Public Const FILE_SKIPPED As Integer = -1           ' File replacement code: Skipped.
         Public Const FILE_OK As Integer = 0                 ' File replacement code: File ok.
         Public Const FILE_REBOOT_REQUIRED As Integer = 1    ' File replacement code: Reboot required.

--- a/WinOffline/PatchVector.vb
+++ b/WinOffline/PatchVector.vb
@@ -23,13 +23,11 @@
         Public Const APPLY_FAIL As Integer = 1              ' Apply action code: Apply fail.
         Public Const EXECUTE_OK As Integer = 2              ' Apply action code: Execute ok.
         Public Const EXECUTE_FAIL As Integer = 3            ' Apply action code: Execute fail.
-        Public Const FILE_REMOVED As Integer = -3           ' File replacement code: New file removed.
-        Public Const FILE_RESTORED As Integer = -2          ' File replacement code: Original restored.
+        Public Const FILE_REVERSED As Integer = -2          ' File replacement code: Reversed.
         Public Const FILE_SKIPPED As Integer = -1           ' File replacement code: Skipped.
         Public Const FILE_OK As Integer = 0                 ' File replacement code: File ok.
         Public Const FILE_REBOOT_REQUIRED As Integer = 1    ' File replacement code: Reboot required.
         Public Const FILE_FAILED As Integer = 2             ' File replacement code: File fail.
-        Public Const FILE_UNCHANGED As Integer = 3          ' File replacement code: Unchanged.
         Private ClientAutoProductCodes = New ArrayList({"BITCM", "DTSVMG", "DTMGSU", "TNGAMO", "TNGSDO", "TNGRCO"})
         Private SharedComponentProductCodes As New ArrayList({"DTMINF"})
         Private CAMProductCodes As New ArrayList({"CCSCAM", "TNGCAM"})
@@ -47,9 +45,11 @@
             _FileReplaceResult = New ArrayList
             _CommentString = ""
 
+
+
             For Each ReplacedFile As String In GetShortNameReplaceList()
                 _SourceReplaceList.Add(_FileName.GetFilePath + "\" + ReplacedFile)
-                _FileReplaceResult.Add(FILE_UNCHANGED)
+                _FileReplaceResult.Add(FILE_SKIPPED)
             Next
 
             For Each ReplacedFile As String In GetRawReplaceList()

--- a/WinOffline/PatchVector.vb
+++ b/WinOffline/PatchVector.vb
@@ -23,6 +23,7 @@
         Public Const APPLY_FAIL As Integer = 1              ' Apply action code: Apply fail.
         Public Const EXECUTE_OK As Integer = 2              ' Apply action code: Execute ok.
         Public Const EXECUTE_FAIL As Integer = 3            ' Apply action code: Execute fail.
+        Public Const FILE_REVERSED As Integer = -2          ' File replacement code: Changes reversed.
         Public Const FILE_SKIPPED As Integer = -1           ' File replacement code: Skipped.
         Public Const FILE_OK As Integer = 0                 ' File replacement code: File ok.
         Public Const FILE_REBOOT_REQUIRED As Integer = 1    ' File replacement code: Reboot required.

--- a/WinOffline/RemovalVector.vb
+++ b/WinOffline/RemovalVector.vb
@@ -19,6 +19,7 @@ Partial Public Class WinOffline
         Public Const SKIPPED As Integer = -1                ' Removal action code: Skipped.
         Public Const REMOVAL_OK As Integer = 0              ' Removal action code: Removal ok.
         Public Const REMOVAL_FAIL As Integer = 1            ' Removal action code: Removal fail.
+        Public Const FILE_REVERSED As Integer = -2          ' File replacement code: Reversed.
         Public Const FILE_SKIPPED As Integer = -1           ' File replacement code: Skipped.
         Public Const FILE_OK As Integer = 0                 ' File replacement code: File ok.
         Public Const FILE_REBOOT_REQUIRED As Integer = 1    ' File replacement code: Reboot required.

--- a/WinOffline/Utility.vb
+++ b/WinOffline/Utility.vb
@@ -578,6 +578,14 @@ Partial Public Class WinOffline
             End Try
         End Function
 
+        Public Shared Function IsFolderEmpty(ByVal FolderName As String) As Boolean
+            If System.IO.Directory.Exists(FolderName) Then
+                If System.IO.Directory.GetDirectories(FolderName).Length > 0 Then Return False
+                If System.IO.Directory.GetFiles(FolderName).Length > 0 Then Return False
+            End If
+            Return True
+        End Function
+
         Public Shared Function IsHexChar(ByVal c As Char) As Boolean
             Dim result As Integer
             If Integer.TryParse(c.ToString, result) AndAlso result >= 0 AndAlso result <= 9 Then Return True


### PR DESCRIPTION
This branch resolves an issue, where patch files go missing after successful decompression on Stage1.  Stage2 does not expect files to be missing, and badly enough, this resulted in original files getting deleted, mid-replacement, and then not getting restored.

So this branch addresses:
1- If the extracted patch folder goes missing (after a successful extraction in Stage1), Stage2 will recognize this, and report the patch status as UNAVAILABLE.

2- If the patch folder is available, but ~some~ files have gone missing, this branch addresses a bug in the code for reversing the file replacements, and all original files should now get restored.  So if the patch replaces 3 files, and the last one has gone "missing", it will restore all three original files, and report an appropriate error in the summary.

3-Inadvertently discovered and fixed an issue with how exceptions are captured and summarized.  Previous code was making an assumption that all exceptions were only two lines, when in fact they can span n-number of lines.  Code updated, summary looks good.

Screenshot showing how a missing file got handled, and I've successfully confirmed on multiple tests with real patches, that original files all got restored, as expected:

![2018-10-19_17-01-41](https://user-images.githubusercontent.com/41308769/47243813-41bf3900-d3c1-11e8-8b0c-eb0d0af4bc50.jpg)

