### PR TITLE
Handle parent folder file replacements

### DIFF
--- a/WinOffline/PatchOperations.vb
+++ b/WinOffline/PatchOperations.vb
@@ -606,15 +606,20 @@
         '       is to be considered a NEW FILE introduced by the application of the patch.
         '       Therefore, on removal of said patch, NEW FILES will simply be deleted, but
         '       also saved in the BACKOUT subfolder.
-        '
-        '       Maintaining a NewFile list is not really necessary, as lower sections of
-        '       code automatically save them to the BACKOUT subsolder and delete them
-        '       where they stand. But I'm leaving this code here for now, in case this
-        '       functionality is changed in the future.
         For Each InstalledFile As String In hVector.GetInstalledFiles
             If hVector.GetProductComponent.Equals(IT_CLIENT_MANAGER) Then
-                SubFolder = InstalledFile.ToLower.Replace(Globals.DSMFolder.ToLower, "")
-                SubFolder = SubFolder.Replace("\\", "\")
+                ' Sometimes the product code is a lie. For example, development coded the patch
+                ' as BITCM or DTSVMG, but then used a "FILE:..\SC\CBB\SomeFile.dat" to subvert the
+                ' product code, and go outside the parent folder to conduct a replacement. Therefore,
+                ' we need to check the InstalledFile path actually contains the DSMFolder, and if not,
+                ' we will check components within SC, followed by the generic SC folder.
+                If InstalledFile.ToLower.Contains(Globals.DSMFolder.ToLower) Then
+                    SubFolder = InstalledFile.ToLower.Replace(Globals.DSMFolder.ToLower, "")
+                    SubFolder = SubFolder.Replace("\\", "\")
+                ElseIf InstalledFile.ToLower.Contains(Globals.CAFolder.ToLower) Then
+                    SubFolder = InstalledFile.ToLower.Replace(Globals.CAFolder.ToLower, "")
+                    SubFolder = SubFolder.Replace("\\", "\")
+                End If
             ElseIf hVector.GetProductComponent.Equals(SHARED_COMPONENTS) Then
                 SubFolder = InstalledFile.ToLower.Replace(Globals.SharedCompFolder.ToLower, "")
                 SubFolder = SubFolder.Replace("\\", "\")
@@ -637,7 +642,7 @@
                 SubFolderList.Add(SubFolder) ' Add subfolder to list (so we don't have to recalculate this later)
             Else
                 NewFileList.Add(InstalledFile)
-                SubFolderList.Add(SubFolder) ' Add subfolder to list (so we don't have to recalculate this later)
+                SubFolderList.Add(SubFolder) ' Add subfolder to list
             End If
         Next
 

--- a/WinOffline/PatchProcessor.vb
+++ b/WinOffline/PatchProcessor.vb
@@ -59,8 +59,7 @@
 
     End Function
 
-    Public Shared Function MigratePatch(ByVal CallStack As String,
-                                        ByVal JCLFileName As String) As Integer
+    Public Shared Function MigratePatch(ByVal CallStack As String, ByVal JCLFileName As String) As Integer
 
         Dim TargetFileName As String        ' Destination filename (e.g. C:\Windows\Temp\WinOffline\SomePatch\SomePatch.jcl).
         Dim RunLevel As Integer = 0
@@ -89,7 +88,7 @@
 
     Public Shared Function DecompressPatch(ByVal CallStack As String, ByVal CAZFileName As String) As Integer
 
-        Dim TargetFileName As String                        ' Destination filename (e.g. C:\Windows\Temp\WinOffline\SomePatch\SomePatch.caz).
+        Dim TargetFileName As String ' Destination filename (e.g. C:\Windows\Temp\WinOffline\SomePatch\SomePatch.caz)
         Dim ExecutionString As String
         Dim ArgumentString As String
         Dim CAZipXPProcessStartInfo As ProcessStartInfo

--- a/WinOffline/PatchProcessor.vb
+++ b/WinOffline/PatchProcessor.vb
@@ -61,7 +61,7 @@
 
     Public Shared Function MigratePatch(ByVal CallStack As String, ByVal JCLFileName As String) As Integer
 
-        Dim TargetFileName As String        ' Destination filename (e.g. C:\Windows\Temp\WinOffline\SomePatch\SomePatch.jcl).
+        Dim TargetFileName As String ' Destination filename (e.g. C:\Windows\Temp\WinOffline\SomePatch\SomePatch.jcl).
         Dim RunLevel As Integer = 0
 
         CallStack += "Migrate|"

--- a/WinOffline/PatchVector.vb
+++ b/WinOffline/PatchVector.vb
@@ -45,8 +45,6 @@
             _FileReplaceResult = New ArrayList
             _CommentString = ""
 
-
-
             For Each ReplacedFile As String In GetShortNameReplaceList()
                 _SourceReplaceList.Add(_FileName.GetFilePath + "\" + ReplacedFile)
                 _FileReplaceResult.Add(FILE_SKIPPED)

--- a/WinOffline/PatchVector.vb
+++ b/WinOffline/PatchVector.vb
@@ -45,14 +45,22 @@
             _FileReplaceResult = New ArrayList
             _CommentString = ""
 
+            ' All these lists are built in parallel with each other:
+            '   _SourceReplaceList --> Replacement source file
+            '   _FileReplaceResult --> Replacement result code
+            '   _DestReplaceList --> Replacement destination file
+            '   _ReplaceSubFolder --> Replacement subfolder
+            '   _ReplaceFolder --> Replacement base folder
+
+            ' Generate source file list and stub SKIPPED for replacement status
             For Each ReplacedFile As String In GetShortNameReplaceList()
                 _SourceReplaceList.Add(_FileName.GetFilePath + "\" + ReplacedFile)
                 _FileReplaceResult.Add(FILE_SKIPPED)
             Next
 
-            Dim ReplaceDestination As String = Nothing
-
+            ' Generate destination file list
             For Each ReplacedFile As String In GetRawReplaceList()
+                Dim ReplaceDestination As String = Nothing
                 If IsClientAuto() Then
                     ReplaceDestination = Globals.DSMFolder + ReplacedFile
                 ElseIf IsSharedComponent() Then
@@ -80,6 +88,7 @@
                 End While
                 _DestReplaceList.Add(ReplaceDestination)
 
+                ' Generate a subfolder list
                 If ReplacedFile.Contains("\") Then
                     _ReplaceSubFolder.Add(ReplacedFile.Substring(0, ReplacedFile.LastIndexOf("\")))
                 Else

--- a/WinOffline/PatchVector.vb
+++ b/WinOffline/PatchVector.vb
@@ -50,24 +50,36 @@
                 _FileReplaceResult.Add(FILE_SKIPPED)
             Next
 
+            Dim ReplaceDestination As String = Nothing
+
             For Each ReplacedFile As String In GetRawReplaceList()
                 If IsClientAuto() Then
-                    _DestReplaceList.Add(Globals.DSMFolder + ReplacedFile)
+                    ReplaceDestination = Globals.DSMFolder + ReplacedFile
                 ElseIf IsSharedComponent() Then
                     If ReplacedFile.ToLower.StartsWith("capki\capki") Then ' Special case -- CAPKI may not be with other shared components
-                        _DestReplaceList.Add(Globals.CAPKIFolder + ReplacedFile.ToLower.Replace("capki\capki", "")) ' Use CAPKI folder
+                        ReplaceDestination = Globals.CAPKIFolder + ReplacedFile.ToLower.Replace("capki\capki", "") ' Use CAPKI folder
                     Else
-                        _DestReplaceList.Add(Globals.SharedCompFolder + ReplacedFile)
+                        ReplaceDestination = Globals.SharedCompFolder + ReplacedFile
                     End If
                 ElseIf IsCAM() Then
-                    _DestReplaceList.Add(Globals.CAMFolder + "\" + ReplacedFile)
+                    ReplaceDestination = Globals.CAMFolder + "\" + ReplacedFile
                 ElseIf IsSSA() Then
-                    _DestReplaceList.Add(Globals.SSAFolder + ReplacedFile)
+                    ReplaceDestination = Globals.SSAFolder + ReplacedFile
                 ElseIf IsDataTransport() Then
-                    _DestReplaceList.Add(Globals.DTSFolder + "\" + ReplacedFile)
+                    ReplaceDestination = Globals.DTSFolder + "\" + ReplacedFile
                 ElseIf IsExplorerGUI() Then
-                    _DestReplaceList.Add(Globals.EGCFolder + ReplacedFile)
+                    ReplaceDestination = Globals.EGCFolder + ReplacedFile
                 End If
+
+                ' Resolve parent directories e.g. D:\CA\DSM\..\SC\CBB\_SomeFile.txt --> D:\CA\SC\CBB\_SomeFile.txt
+                While ReplaceDestination.Contains("\..\")
+                    Dim Front As String = ReplaceDestination.Substring(0, ReplaceDestination.IndexOf("\..\"))
+                    Front = Front.Substring(0, Front.LastIndexOf("\"))
+                    Dim Back As String = ReplaceDestination.Substring(ReplaceDestination.IndexOf("\..\") + 3)
+                    ReplaceDestination = Front + Back
+                End While
+                _DestReplaceList.Add(ReplaceDestination)
+
                 If ReplacedFile.Contains("\") Then
                     _ReplaceSubFolder.Add(ReplacedFile.Substring(0, ReplacedFile.LastIndexOf("\")))
                 Else


### PR DESCRIPTION
Resolved issues with applying and removing patches, where the original JCL contained ..\ (parent folder) references in the file replacement.  This happens when the developer of the patch codes it generically for BITCM or DTSVMG, but subverts the code by going outside the base folder for that file replacement.  It's rare, but it happens.  Code updates for both applying and removing patches with this have been made.