### PR TITLE
Support for 'POSTSYSCMD' directive inside JCL files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ VERSIONCHECK
 > Designate patch is ITCM version specific. The patch will be SKIPPED if the version does not match.
 
 > Examples:  
-VERSIONCHECK:12.9.0.338  
 VERSIONCHECK:14.0.0.199  
 VERSIONCHECK:14.0.1000.194  
 VERSIONCHECK:14.0.2000.255  
@@ -62,6 +61,34 @@ PRODUCT:DTSVMG
 FILE:bin\cfsmcapi.dll
 FILE:bin\cfmessenger.dll
 VERSIONCHECK:12.9.0.338
+```
+
+POSTSYSCMD
+> Execute additional script(s) after the CAF service has been restarted.
+
+Sample JCL file with POSTSYSCMD:
+```
+PLATFORM:WINDOWS
+PRODUCT:DTSVMG
+COMPONENT:DTSVMG-DTSVMG
+RELEASE:R14
+GENLEVEL:SP2
+VERSION:20010222
+PREREQS:
+MPREREQS:
+COREQS:
+MCOREQS:
+VERSIONCHECK:14.0.2000.255
+PRESYSCMD:Install-VC-Redist-x86.cmd
+DEPENDS:vc_redist.x86.exe
+FILE:bin\RCGraphics.dll:SKIPIFNOTFOUND:
+FILE:bin\rcHost.exe:SKIPIFNOTFOUND:
+FILE:bin\RCOS.dll:SKIPIFNOTFOUND:
+FILE:bin\rcPropDialog.dll:SKIPIFNOTFOUND:
+FILE:bin\rcPropDialog_EN.dll:SKIPIFNOTFOUND:
+FILE:bin\rcVideoCapture.dll:SKIPIFNOTFOUND:
+POSTSYSCMD:Import-Policy.cmd
+DEPENDS:rcHostConfig_sep.xml
 ```
 
 DEPENDS
@@ -89,6 +116,7 @@ JCL file requirements and formatting:
 > * WinOffline supportd JCLs having multiple insturction tags (PRESYSCMD, FILE, or SYSCMD).
 > * WinOffline always runs the PRESYSCMD tags, in the order they are found, before performing FILE replacements.
 > * WinOffline always runs the SYSCMD tags, in the order they are found, after performing FILE replacements.
+> * WinOffline always runs the POSTSYSCMD tags, in the order they are found, after the CAF service is restarted.
 > * Similar to the DEPENDS tag, WinOffline also supports multiple comma separated items in the PRESYSCMD or SYSCMD tags.
 
 Here's a sample JCL file:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ VERSIONCHECK:12.9.0.338
 ```
 
 POSTSYSCMD
-> Execute additional script(s) after the CAF service has been restarted.
+> Execute additional script(s) after the CAF service has been restarted since patching.
 
 Sample JCL file with POSTSYSCMD:
 ```
@@ -118,20 +118,6 @@ JCL file requirements and formatting:
 > * WinOffline always runs the SYSCMD tags, in the order they are found, after performing FILE replacements.
 > * WinOffline always runs the POSTSYSCMD tags, in the order they are found, after the CAF service is restarted.
 > * Similar to the DEPENDS tag, WinOffline also supports multiple comma separated items in the PRESYSCMD or SYSCMD tags.
-
-Here's a sample JCL file:
-```
-PLATFORM:WINDOWS
-PRODUCT:BITCM
-PRESYSCMD:ScriptA.cmd
-DEPENDS:ScriptC.cmd
-FILE:bin\_SomeFile.txt
-FILE:bin\_SomeFile2.txt
-SYSCMD:ScriptB.cmd
-SYSCMD:ScriptF.cmd,ScriptG.cmd
-DEPENDS:ScriptD.cmd,ScriptE.cmd
-VERSIONCHECK:14.0.1000.194
-```
 
 ## WinOffline Command Line Switches
 

--- a/WinOffline/Globals.vb
+++ b/WinOffline/Globals.vb
@@ -4,7 +4,7 @@ Public Class Globals
 
     ' WinOffline and System Globals
     Public Shared CommandLineArgs As String() = Nothing                         ' Command line arguments passed to the application.
-    Public Shared AppVersion As String = "2018.10.23"                           ' Version string of the current build.
+    Public Shared AppVersion As String = "2018.12.28"                           ' Version string of the current build.
     Public Shared ProcessName As String = Nothing                               ' Fullpath including filename of the application process.
     Public Shared ProcessShortName As String = Nothing                          ' Filename of the application process.
     Public Shared ProcessFriendlyName As String = Nothing                       ' Friendly name of the application process.

--- a/WinOffline/Manifest.vb
+++ b/WinOffline/Manifest.vb
@@ -460,6 +460,17 @@
                                 End If
                             Next
 
+                            For x As Integer = 0 To GetPatchFromManifest(i).GetPostCommandList.Count - 1
+                                CommandFile = GetPatchFromManifest(i).GetPostCommandList.Item(x)
+                                If GetPatchFromManifest(i).PostCmdReturnCodes.Count > x Then
+                                    ReturnCode = GetPatchFromManifest(i).PostCmdReturnCodes.Item(x)
+                                    PatchSummary += "- " + CommandFile + " [Return Code: " + ReturnCode + "]" + Environment.NewLine
+                                Else
+                                    ReturnCode = "NOT EXECUTED"
+                                    PatchSummary += "- " + CommandFile + " [" + ReturnCode + "]" + Environment.NewLine
+                                End If
+                            Next
+
                         End If
                         PatchSummary += Environment.NewLine
                     Next

--- a/WinOffline/My Project/AssemblyInfo.vb
+++ b/WinOffline/My Project/AssemblyInfo.vb
@@ -9,8 +9,8 @@ Imports System.Runtime.InteropServices
 ' Review the values of the assembly attributes
 
 <Assembly: AssemblyTitle("WinOffline")> 
-<Assembly: AssemblyDescription("")> 
-<Assembly: AssemblyCompany("CA Technologies, Inc.")> 
+<Assembly: AssemblyDescription("")>
+<Assembly: AssemblyCompany("")>
 <Assembly: AssemblyProduct("WinOffline")>
 <Assembly: AssemblyCopyright("")>
 <Assembly: AssemblyTrademark("")> 
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("2018.10.23")>
-<Assembly: AssemblyFileVersion("2018.10.23")>
+<Assembly: AssemblyVersion("2018.12.28")>
+<Assembly: AssemblyFileVersion("2018.12.28")>

--- a/WinOffline/PatchOperations.vb
+++ b/WinOffline/PatchOperations.vb
@@ -185,7 +185,7 @@
 
     End Sub
 
-    Public Shared Sub ExecutePostCmd(ByVal CallStack As String, ByRef pVector As PatchVector)
+    Public Shared Sub ExecuteSysCmd(ByVal CallStack As String, ByRef pVector As PatchVector)
 
         Dim ExecutionString As String
         Dim ProcessStartInfo As ProcessStartInfo
@@ -475,7 +475,7 @@
 
         ' Run SYSCMD sripts
         Try
-            ExecutePostCmd(CallStack, pVector)
+            ExecuteSysCmd(CallStack, pVector)
         Catch ex As Exception
             Logger.WriteDebug(CallStack, "Error: Execution of SYSCMD script(s) failed.")
             Logger.WriteDebug(ex.Message)

--- a/WinOffline/PatchOperations.vb
+++ b/WinOffline/PatchOperations.vb
@@ -269,7 +269,7 @@
             Logger.WriteDebug("------------------------------------------------------------")
             Logger.WriteDebug(CallStack, "Exit code: " + RunningProcess.ExitCode.ToString)
 
-            pVector.SysCmdReturnCodes.Add(RunningProcess.ExitCode.ToString)
+            pVector.PostCmdReturnCodes.Add(RunningProcess.ExitCode.ToString)
             RunningProcess.Close()
         Next
 

--- a/WinOffline/PatchProcessor.vb
+++ b/WinOffline/PatchProcessor.vb
@@ -240,11 +240,11 @@
                                     "Please verify the PRODUCT: tag in the patch file."})
             Return 4
         End If
-        If NewPatch.GetShortNameReplaceList.Count + NewPatch.GetPreCommandList.Count + NewPatch.GetSysCommandList.Count = 0 Then
-            Logger.WriteDebug(CallStack, "Error: Patch file is missing instructions (i.e. 'FILE:', 'PRESYSCMD:' or 'SYSCMD:' tags).")
+        If NewPatch.GetShortNameReplaceList.Count + NewPatch.GetPreCommandList.Count + NewPatch.GetSysCommandList.Count + NewPatch.GetPostCommandList.Count = 0 Then
+            Logger.WriteDebug(CallStack, "Error: Patch file is missing instructions (i.e. 'FILE:', 'PRESYSCMD:', 'SYSCMD:' or 'POSTSYSCMD:' tags).")
             Manifest.UpdateManifest(CallStack,
                                     Manifest.EXCEPTION_MANIFEST,
-                                    {"Error: Patch file is missing instructions (i.e. 'FILE:', 'PRESYSCMD:' or 'SYSCMD:' tags).",
+                                    {"Error: Patch file is missing instructions (i.e. 'FILE:', 'PRESYSCMD:', 'SYSCMD:', 'POSTSYSCMD:' tags).",
                                     "Please verify the " + NewPatch.PatchFile.GetShortName + " patch."})
             Return 5
         End If

--- a/WinOffline/PatchVector.vb
+++ b/WinOffline/PatchVector.vb
@@ -312,11 +312,11 @@
                 ReturnString += GetRawInstruction("RELEASE").Replace(":", "=") + Environment.NewLine
                 ReturnString += GetRawInstruction("GENLEVEL").Replace(":", "=") + Environment.NewLine
                 ReturnString += GetRawInstruction("COMPONENT").Replace(":", "=") + Environment.NewLine
-                If Not GetRawInstruction("PREREQS").Equals("") Then ReturnString += GetRawInstruction("PREREQS").Replace(":", "=") + Environment.NewLine
-                If Not GetRawInstruction("MPREREQS").Equals("") Then ReturnString += GetRawInstruction("MPREREQS").Replace(":", "=") + Environment.NewLine
-                If Not GetRawInstruction("COREQS").Equals("") Then ReturnString += GetRawInstruction("COREQS").Replace(":", "=") + Environment.NewLine
-                If Not GetRawInstruction("MCOREQS").Equals("") Then ReturnString += GetRawInstruction("MCOREQS").Replace(":", "=") + Environment.NewLine
-                If Not GetRawInstruction("SUPERSEDE").Equals("") Then ReturnString += GetRawInstruction("SUPERSEDE").Replace(":", "=")
+                If Not GetRawInstruction("PREREQS").Equals("") Then ReturnString += GetRawInstruction("PREREQS").Replace(":", "=") + Environment.NewLine Else ReturnString += "PREREQS=" + Environment.NewLine
+                If Not GetRawInstruction("MPREREQS").Equals("") Then ReturnString += GetRawInstruction("MPREREQS").Replace(":", "=") + Environment.NewLine Else ReturnString += "MPREREQS=" + Environment.NewLine
+                If Not GetRawInstruction("COREQS").Equals("") Then ReturnString += GetRawInstruction("COREQS").Replace(":", "=") + Environment.NewLine Else ReturnString += "COREQS=" + Environment.NewLine
+                If Not GetRawInstruction("MCOREQS").Equals("") Then ReturnString += GetRawInstruction("MCOREQS").Replace(":", "=") + Environment.NewLine Else ReturnString += "MCOREQS=" + Environment.NewLine
+                If Not GetRawInstruction("SUPERSEDE").Equals("") Then ReturnString += GetRawInstruction("SUPERSEDE").Replace(":", "=") Else ReturnString += "SUPERSEDE="
                 For x As Integer = 0 To _DestReplaceList.Count - 1
                     Dim strLine As String = _DestReplaceList.Item(x)
                     If _FileReplaceResult.Item(x) = FILE_OK Or _FileReplaceResult.Item(x) = FILE_REBOOT_REQUIRED Then

--- a/WinOffline/PatchVector.vb
+++ b/WinOffline/PatchVector.vb
@@ -291,11 +291,11 @@
                 ReturnString += GetRawInstruction("RELEASE").Replace(":", "=") + Environment.NewLine
                 ReturnString += GetRawInstruction("GENLEVEL").Replace(":", "=") + Environment.NewLine
                 ReturnString += GetRawInstruction("COMPONENT").Replace(":", "=") + Environment.NewLine
-                ReturnString += GetRawInstruction("PREREQS").Replace(":", "=") + Environment.NewLine
-                ReturnString += GetRawInstruction("MPREREQS").Replace(":", "=") + Environment.NewLine
-                ReturnString += GetRawInstruction("COREQS").Replace(":", "=") + Environment.NewLine
-                ReturnString += GetRawInstruction("MCOREQS").Replace(":", "=") + Environment.NewLine
-                ReturnString += GetRawInstruction("SUPERSEDE").Replace(":", "=")
+                If Not GetRawInstruction("PREREQS").Equals("") Then ReturnString += GetRawInstruction("PREREQS").Replace(":", "=") + Environment.NewLine
+                If Not GetRawInstruction("MPREREQS").Equals("") Then ReturnString += GetRawInstruction("MPREREQS").Replace(":", "=") + Environment.NewLine
+                If Not GetRawInstruction("COREQS").Equals("") Then ReturnString += GetRawInstruction("COREQS").Replace(":", "=") + Environment.NewLine
+                If Not GetRawInstruction("MCOREQS").Equals("") Then ReturnString += GetRawInstruction("MCOREQS").Replace(":", "=") + Environment.NewLine
+                If Not GetRawInstruction("SUPERSEDE").Equals("") Then ReturnString += GetRawInstruction("SUPERSEDE").Replace(":", "=")
                 For x As Integer = 0 To _DestReplaceList.Count - 1
                     Dim strLine As String = _DestReplaceList.Item(x)
                     If _FileReplaceResult.Item(x) = FILE_OK Or _FileReplaceResult.Item(x) = FILE_REBOOT_REQUIRED Then

--- a/WinOffline/PatchVector.vb
+++ b/WinOffline/PatchVector.vb
@@ -7,6 +7,7 @@
         Private _PatchAction As Integer                     ' Action code/result from applying patch.
         Private _PreCmdReturnCodes As ArrayList             ' Stores return codes from all PRESYSCMD scripts.
         Private _SysCmdReturnCodes As ArrayList             ' Stores return codes from all SYSCMD scripts.
+        Private _PostCmdReturnCodes As ArrayList            ' Stores return codes from all POSTSYSCMD scripts.
         Private _FileReplaceResult As ArrayList             ' Stores result of file replacement operations.
         Private _CommentString As String                    ' Stores a comment.
         Private _SourceReplaceList As New ArrayList         ' Source location filename for each file replacement.
@@ -42,6 +43,7 @@
             _PatchAction = NO_ACTION
             _PreCmdReturnCodes = New ArrayList
             _SysCmdReturnCodes = New ArrayList
+            _PostCmdReturnCodes = New ArrayList
             _FileReplaceResult = New ArrayList
             _CommentString = ""
 
@@ -226,6 +228,22 @@
             Dim ReturnList As New ArrayList
             For Each strLine As String In InstructionList
                 If strLine.ToLower.StartsWith("syscmd:") Then
+                    strLine = strLine.Substring(strLine.IndexOf(":") + 1)
+                    strLine = strLine.Replace(" ", "")
+                    If strLine.Contains(",") Then
+                        ReturnList.AddRange(strLine.Split(","))
+                    Else
+                        ReturnList.Add(strLine)
+                    End If
+                End If
+            Next
+            Return ReturnList
+        End Function
+
+        Public Function GetPostCommandList() As ArrayList
+            Dim ReturnList As New ArrayList
+            For Each strLine As String In InstructionList
+                If strLine.ToLower.StartsWith("postsyscmd:") Then
                     strLine = strLine.Substring(strLine.IndexOf(":") + 1)
                     strLine = strLine.Replace(" ", "")
                     If strLine.Contains(",") Then
@@ -426,6 +444,16 @@
                 _SysCmdReturnCodes = value.Clone
             End Set
         End Property
+
+        Public Property PostCmdReturnCodes As ArrayList
+            Get
+                Return _PostCmdReturnCodes
+            End Get
+            Set(value As ArrayList)
+                _PostCmdReturnCodes = value.Clone
+            End Set
+        End Property
+
         Public Property FileReplaceResult As ArrayList
             Get
                 Return _FileReplaceResult
@@ -489,6 +517,10 @@
             For Each strLine As String In _SysCmdReturnCodes
                 ReturnString += strLine + ";"
             Next
+            ReturnString += Environment.NewLine() + "POSTSYSCMD:"
+            For Each strLine As String In _PostCmdReturnCodes
+                ReturnString += strLine + ";"
+            Next
             ReturnString += Environment.NewLine() + "FILE_REPLACE:"
             For Each strLine As String In _FileReplaceResult
                 ReturnString += strLine + ";"
@@ -543,6 +575,15 @@
                     strLine2 = strLine2.Substring(strLine2.IndexOf(";") + 1)
                 End While
                 pVector.SysCmdReturnCodes = CodeList
+                strLine2 = CacheReader.ReadLine ' Read POSTSYSCMD return codes
+                strLine2 = strLine2.Replace("POSTSYSCMD:", "")
+                CodeList = New ArrayList
+                While strLine2.Contains(";") And strLine2.Length > 1
+                    strLine3 = strLine2.Substring(0, strLine2.IndexOf(";"))
+                    CodeList.Add(strLine3)
+                    strLine2 = strLine2.Substring(strLine2.IndexOf(";") + 1)
+                End While
+                pVector.PostCmdReturnCodes = CodeList
                 strLine2 = CacheReader.ReadLine ' Read file replacement codes
                 strLine2 = strLine2.Replace("FILE_REPLACE:", "")
                 CodeList = New ArrayList

--- a/WinOffline/PatchVector.vb
+++ b/WinOffline/PatchVector.vb
@@ -283,6 +283,9 @@
             For Each strLine As String In GetSysCommandList()
                 ReturnArray.Add(strLine)
             Next
+            For Each strLine As String In GetPostCommandList()
+                ReturnArray.Add(strLine)
+            Next
             For Each strLine As String In GetDependsList()
                 ReturnArray.Add(strLine)
             Next


### PR DESCRIPTION
Enhancement to add support for a 'POSTSYSCMD' inside a JCL patch.  This allows WinOffline to run any script(s) after CAF has been started back up from patching.  The existing 'PRESYSCMD' and 'SYSCMD' tags are executed while CAF is stopped, and in some cases, we need to automate something post-patching, but only after CAF is running again.  An example of this is ccnfregdb to merge new policies into the comstore. This PostSysCmd tag will improve the automation capabilities of WinOffline.